### PR TITLE
Add api/clientConfig to more easily configure the clientConfig

### DIFF
--- a/src/base/clientConfig.ts
+++ b/src/base/clientConfig.ts
@@ -5,10 +5,20 @@ export interface ITDPClientConfig {
 }
 
 /**
- * Loads the client config from '/clientConfig.json' and parses it.
+ * Loads the client config from '/api/clientConfig' or '/clientConfig.json' and parses it.
  */
 export async function loadClientConfig<T = any>(): Promise<T | null> {
-  return Ajax.getJSON('/clientConfig.json').catch(() => {
-    return null;
-  });
+  return Ajax.getJSON('/api/clientConfig')
+    .catch((e) => {
+      console.error('Error loading /api/clientConfig', e);
+      return null;
+    })
+    .then((r) => {
+      if (r == null) {
+        return Ajax.getJSON('/clientConfig.json').catch(() => {
+          return null;
+        });
+      }
+      return r;
+    });
 }

--- a/visyn_core/__init__.py
+++ b/visyn_core/__init__.py
@@ -17,6 +17,10 @@ class VisynPlugin(AVisynPlugin):
                 "RDKit is not installed, corresponding API could not be loaded. Consider installing visyn_core[full] or visyn_core[rdkit]."
             )
 
+        from .settings.router import create as create_settings_router
+
+        app.include_router(create_settings_router(app))
+
     def register(self, registry: RegHelper):
         # phovea_server
         registry.append(
@@ -28,7 +32,6 @@ class VisynPlugin(AVisynPlugin):
 
         # General routers
         registry.append("namespace", "visyn_core_main", "visyn_core.server.mainapp", {"namespace": "/app"})
-        registry.append_router("visyn_config_router", "visyn_core.settings.router", {})
         registry.append_router("visyn_plugin_router", "visyn_core.plugin.router", {})
         registry.append("namespace", "visyn_xlsx2json", "visyn_core.xlsx", {"namespace": "/api/tdp/xlsx"})
 

--- a/visyn_core/settings/model.py
+++ b/visyn_core/settings/model.py
@@ -84,6 +84,9 @@ class VisynCoreSettings(BaseModel):
     """Deprecated: use visyn_core.security.store.dummy_store.enable instead."""
     security: SecuritySettings = SecuritySettings()
 
+    client_config: dict[str, Any] | None = None
+    """Client config to be loaded via /api/clientConfig"""
+
 
 class GlobalSettings(BaseSettings):
     env: Literal["development", "production"] = "production"

--- a/visyn_core/settings/router.py
+++ b/visyn_core/settings/router.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter, Depends, HTTPException
+from typing import Any
+
+from fastapi import APIRouter, Depends, FastAPI, HTTPException
 
 from .. import manager
 from ..security.dependencies import get_current_user
@@ -21,5 +23,9 @@ def get_config_path(path: str):
     return manager.settings.get_nested(".".join(split_path))
 
 
-def create():
+def create(app: FastAPI) -> APIRouter:
+    @app.get("/api/clientConfig", tags=["Configuration"])
+    def get_client_config() -> dict[str, Any] | None:
+        return manager.settings.visyn_core.client_config
+
     return router

--- a/visyn_core/tests/test_settings.py
+++ b/visyn_core/tests/test_settings.py
@@ -1,6 +1,9 @@
 import os
 from unittest import mock
 
+from starlette.testclient import TestClient
+
+from visyn_core import manager
 from visyn_core.settings.model import GlobalSettings
 
 
@@ -38,3 +41,14 @@ def test_env_substitution():
             env_settings.get_nested("visyn_core.logging.version") == "2"
         )  # Note that this is a string, as it cannot infer the type of Dict
         assert env_settings.get_nested("visyn_core.logging.root.level") == "DEBUG"
+
+
+def test_client_config(client: TestClient):
+    # By default, we always return null for the clientConfig
+    assert client.get("/api/clientConfig").json() is None
+
+    # Update the clientConfig in the settings
+    manager.settings.visyn_core.client_config = {"demo": True}
+
+    # Assert we receive exactly the client_config as result
+    assert client.get("/api/clientConfig").json() == {"demo": True}


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [x] Unit tests are written (frontend/backend if applicable)
- [x] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [ ] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Adds a `/api/clientConfig` route to more easily configure the clientConfig, as previously it was required to be mounted as static file `/clientConfig.json`. Now, if `/api/clientConfig` is not null, it will this instead. 

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
