### PR TITLE
Hide dragmode UI option

### DIFF
--- a/src/vis/Vis.tsx
+++ b/src/vis/Vis.tsx
@@ -39,6 +39,7 @@ export function EagerVis({
   externalConfig = null,
   enableSidebar = true,
   showSidebar: internalShowSidebar,
+  showDragModeOptions = true,
   setShowSidebar: internalSetShowSidebar,
   showSidebarDefault = false,
   scrollZoom = true,
@@ -73,6 +74,7 @@ export function EagerVis({
   externalConfig?: IVisConfig;
   enableSidebar?: boolean;
   showSidebar?: boolean;
+  showDragModeOptions?: boolean;
   setShowSidebar?(show: boolean): void;
   showSidebarDefault?: boolean;
   scrollZoom?: boolean;
@@ -219,6 +221,7 @@ export function EagerVis({
               enable: true,
             },
           }}
+          showDragModeOptions={showDragModeOptions}
           shapes={shapes}
           setConfig={setVisConfig}
           filterCallback={filterCallback}

--- a/src/vis/scatter/ScatterVis.tsx
+++ b/src/vis/scatter/ScatterVis.tsx
@@ -41,6 +41,7 @@ export function ScatterVis({
   showSidebar,
   showCloseButton = false,
   closeButtonCallback = () => null,
+  showDragModeOptions,
   scales,
   scrollZoom,
 }: {
@@ -78,6 +79,7 @@ export function ScatterVis({
   setShowSidebar?(show: boolean): void;
   enableSidebar?: boolean;
   showCloseButton?: boolean;
+  showDragModeOptions: boolean;
   scrollZoom?: boolean;
 }) {
   const id = React.useMemo(() => uniqueId('ScatterVis'), []);
@@ -252,11 +254,14 @@ export function ScatterVis({
       {showCloseButton ? <CloseButton closeCallback={closeButtonCallback} /> : null}
 
       <Stack spacing={0} sx={{ height: '100%' }}>
-        <Center>
-          <Group mt="lg">
-            <BrushOptionButtons callback={(dragMode: EScatterSelectSettings) => setConfig({ ...config, dragMode })} dragMode={config.dragMode} />
-          </Group>
-        </Center>
+        {showDragModeOptions ? (
+          <Center>
+            <Group mt="lg">
+              <BrushOptionButtons callback={(dragMode: EScatterSelectSettings) => setConfig({ ...config, dragMode })} dragMode={config.dragMode} />
+            </Group>
+          </Center>
+        ) : null}
+
         {mergedExtensions.prePlot}
         {traceStatus === 'success' && layout && plotsWithSelectedPoints.length > 0 ? (
           plotly


### PR DESCRIPTION

### Developer Checklist (Definition of Done)

**Issue**

- [ ] All acceptance criteria from the issue are met
- [ ] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [ ] Branch is up-to-date with the branch to be merged with, i.e., develop
- [ ] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [ ] Descriptive title for this pull request is provided (will be used for release notes later)
- [ ] Reviewer and assignees are defined
- [ ] Add type label (e.g., *bug*, *feature*) to this pull request
- [ ] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [ ] The PR is connected to the corresponding issue (via `Closes #...`)
- [ ] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Very small change to allow for the hiding of the dragmode options for scatterplots

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
