### PR TITLE
fix: avoid unmount if client config is reloaded

### DIFF
--- a/src/app/VisynAppProvider.tsx
+++ b/src/app/VisynAppProvider.tsx
@@ -22,6 +22,15 @@ export function VisynAppProvider({
   const { status: initStatus } = useInitVisynApp();
 
   const { value: clientConfig, status: clientConfigStatus, execute } = useAsync(loadClientConfig, []);
+  const [successfulClientConfigInit, setSuccessfulClientConfigInit] = React.useState<boolean>(false);
+
+  React.useEffect(() => {
+    // Once the client config is loaded, we can set the successful client config init.
+    // This is required as when the user changes, we reload the client config but don't want to trigger a complete unmount.
+    if (clientConfigStatus === 'success') {
+      setSuccessfulClientConfigInit(true);
+    }
+  }, [clientConfigStatus]);
 
   React.useEffect(() => {
     // Whenever the user changes, we want to reload the client config to get the latest permissions.
@@ -41,7 +50,7 @@ export function VisynAppProvider({
 
   return (
     <MantineProvider {...mergedMantineProviderProps}>
-      <VisynAppContext.Provider value={context}>{initStatus === 'success' && clientConfigStatus === 'success' ? children : null}</VisynAppContext.Provider>
+      <VisynAppContext.Provider value={context}>{initStatus === 'success' && successfulClientConfigInit ? children : null}</VisynAppContext.Provider>
     </MantineProvider>
   );
 }


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Avoid unmounting the app if the client config reloads due to a change of the user

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
