### PR TITLE
Change order of init_app to ensure every visyn feature is initialized

### DIFF
--- a/visyn_core/server/visyn_server.py
+++ b/visyn_core/server/visyn_server.py
@@ -138,22 +138,6 @@ def create_visyn_server(
     # Load all namespace plugins as WSGIMiddleware plugins
     for p in router_plugins:
         app.include_router(p.load().factory())
-
-    # load `after_server_started` extension points which are run immediately after server started,
-    # so all plugins should have been loaded at this point of time
-    # the hooks are run in a separate (single) thread to not block the main execution of the server
-    # TODO: Use FastAPI mechanism for that
-    t = threading.Thread(target=load_after_server_started_hooks)
-    t.daemon = True
-    t.start()
-
-    # TODO: Check mainapp.py what it does and transfer them here. Currently, we cannot mount a flask app at root, such that the flask app is now mounted at /app/
-    from .mainapp import build_info, health
-
-    # Call init_app callback for every plugin
-    for p in plugins:
-        p.plugin.init_app(app)
-
     from ..middleware.request_context_plugin import RequestContextPlugin
 
     # Use starlette-context to store the current request globally, i.e. accessible via context['request']
@@ -164,6 +148,9 @@ def create_visyn_server(
             return 'GET /health HTTP/1.1" 200' not in record.getMessage()
 
     logging.getLogger("uvicorn.access").addFilter(UvicornAccessLogFilter())
+
+    # TODO: Check mainapp.py what it does and transfer them here. Currently, we cannot mount a flask app at root, such that the flask app is now mounted at /app/
+    from .mainapp import build_info, health
 
     app.add_api_route("/health", health)  # type: ignore
     app.add_api_route("/api/buildInfo.json", build_info)  # type: ignore
@@ -181,5 +168,17 @@ def create_visyn_server(
 
     if manager.settings.visyn_core.cypress:
         _log.info("Cypress mode is enabled. This should only be used in a Cypress testing environment or CI.")
+
+    # As a last step, call init_app callback for every plugin. This is last to ensure everything we need is already initialized.
+    for p in plugins:
+        p.plugin.init_app(app)
+
+    # Load `after_server_started` extension points which are run immediately after server started,
+    # so all plugins should have been loaded at this point of time
+    # the hooks are run in a separate (single) thread to not block the main execution of the server
+    # TODO: Use FastAPI mechanism for that
+    t = threading.Thread(target=load_after_server_started_hooks)
+    t.daemon = True
+    t.start()
 
     return app


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [ ] All acceptance criteria from the issue are met
- [ ] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [ ] Branch is up-to-date with the branch to be merged with, i.e., develop
- [ ] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [ ] Descriptive title for this pull request is provided (will be used for release notes later)
- [ ] Reviewer and assignees are defined
- [ ] Add type label (e.g., *bug*, *feature*) to this pull request
- [ ] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [ ] The PR is connected to the corresponding issue (via `Closes #...`)
- [ ] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Changes the order of initialization calls to ensure the `init_app` is called after everything else is loaded. 

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
