### PR TITLE
fix: add context middleware last to ensure it is loaded after init_app

### DIFF
--- a/visyn_core/server/visyn_server.py
+++ b/visyn_core/server/visyn_server.py
@@ -138,10 +138,6 @@ def create_visyn_server(
     # Load all namespace plugins as WSGIMiddleware plugins
     for p in router_plugins:
         app.include_router(p.load().factory())
-    from ..middleware.request_context_plugin import RequestContextPlugin
-
-    # Use starlette-context to store the current request globally, i.e. accessible via context['request']
-    app.add_middleware(RawContextMiddleware, plugins=(RequestContextPlugin(),))
 
     class UvicornAccessLogFilter(logging.Filter):
         def filter(self, record: logging.LogRecord) -> bool:
@@ -180,5 +176,10 @@ def create_visyn_server(
     from ..settings.client_config import init_client_config
 
     init_client_config(app)
+
+    from ..middleware.request_context_plugin import RequestContextPlugin
+
+    # Use starlette-context to store the current request globally, i.e. accessible via context['request']
+    app.add_middleware(RawContextMiddleware, plugins=(RequestContextPlugin(),))
 
     return app


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [ ] All acceptance criteria from the issue are met
- [ ] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [ ] Branch is up-to-date with the branch to be merged with, i.e., develop
- [ ] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [ ] Descriptive title for this pull request is provided (will be used for release notes later)
- [ ] Reviewer and assignees are defined
- [ ] Add type label (e.g., *bug*, *feature*) to this pull request
- [ ] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [ ] The PR is connected to the corresponding issue (via `Closes #...`)
- [ ] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Add `RequestContextPlugin` very last to ensure it is the last middleware (i.e. after init_app). 

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
