### PR TITLE
Fix: Pin pyright to version 1.1.308

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 black~=22.12.0
-pyright~=1.1.285
+pyright==1.1.308
 pytest-runner~=6.0.0
 pytest~=7.2.0
 ruff==0.0.218


### PR DESCRIPTION
As pyright fails with the following error with version 1.1.309, we now pinned it to version 1.1.308

```
pyright visyn_core setup.py
/home/daniela/Workspaces/standalone_repos/visyn_core/visyn_core/xlsx.py
  /home/daniela/Workspaces/standalone_repos/visyn_core/visyn_core/xlsx.py:62:67 - error: "object*" is not iterable
    "__iter__" method not defined (reportGeneralTypeIssues)
  /home/daniela/Workspaces/standalone_repos/visyn_core/visyn_core/xlsx.py:51:13 - error: "object*" is not iterable
    "__iter__" method not defined (reportGeneralTypeIssues)
/home/daniela/Workspaces/standalone_repos/visyn_core/visyn_core/id_mapping/manager.py
  /home/daniela/Workspaces/standalone_repos/visyn_core/visyn_core/id_mapping/manager.py:98:17 - error: "object*" is not iterable
    "__iter__" method not defined (reportGeneralTypeIssues)
3 errors, 0 warnings, 0 informations 
make: *** [Makefile:30: lint] Error 1
```