### PR TITLE
feat: add oauth2_access_token to User model

### DIFF
--- a/visyn_core/security/model.py
+++ b/visyn_core/security/model.py
@@ -19,6 +19,14 @@ class User(BaseModel):
     id: str
     roles: list[str] = []
     access_token: str | None = None
+    """
+    The access token is set when users login with the native JWT mechanism.
+    """
+    oauth2_access_token: str | None = None
+    """
+    OAuth2 access token as many security stores (like ALB or OAuth2) only parse an already existing access token from an IdP.
+    This token can then be used for downstream tasks like requests to other services.
+    """
 
     @property
     def name(self):

--- a/visyn_core/security/store/alb_security_store.py
+++ b/visyn_core/security/store/alb_security_store.py
@@ -25,7 +25,11 @@ class ALBSecurityStore(BaseStore):
                 user = jwt.decode(encoded, options={"verify_signature": False})
                 # Create new user from given attributes
                 email = user["email"]
-                return User(id=email, roles=[])
+                return User(
+                    id=email,
+                    roles=[],
+                    oauth2_access_token=req.headers["X-Amzn-Oidc-Accesstoken"],
+                )
             except Exception:
                 _log.exception("Error in load_from_request")
                 return None

--- a/visyn_core/tests/test_security_login.py
+++ b/visyn_core/tests/test_security_login.py
@@ -1,3 +1,4 @@
+import jwt
 from fastapi.testclient import TestClient
 
 from visyn_core import manager
@@ -165,7 +166,7 @@ def test_oauth2_security_store(client: TestClient):
 
     # Header created with a random token containing "email"
     headers = {
-        "X-Forwarded-Access-Token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6ImFkbWluQGxvY2FsaG9zdCIsInN1YiI6ImFkbWluIiwicm9sZXMiOlsiYWRtaW4iXSwiZXhwIjoxNjU3MTg4MTM4LjQ5NDU4Nn0.-Ye9j9z37gJdoKgrbeYbI8buSw_c6bLBShXt4XxwQHI",
+        "X-Forwarded-Access-Token": jwt.encode({"email": "admin@localhost", "sub": "admin"}, "secret", algorithm="HS256"),
     }
 
     # Check loggedinas with a JWT


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [ ] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [x] Unit tests are written (end/backend if applicable)
- [x] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [ ] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Some of our stores are just parsing the access token from an IdP and get the user from that. Here, we now add the ability to store the underlying oauth2 access token and use it for downstream tasks like requests to other services. This is for example required for apps using the on-behalf of flow to access other apps.

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
