### PR TITLE
feat: add `log_level` config value to settings

### DIFF
--- a/visyn_core/server/visyn_server.py
+++ b/visyn_core/server/visyn_server.py
@@ -46,8 +46,11 @@ def create_visyn_server(
     # Initialize the logging
     logging_config = manager.settings.visyn_core.logging
 
-    if manager.settings.visyn_core.logging_level:
-        logging_config["root"]["level"] = manager.settings.visyn_core.logging_level
+    if manager.settings.visyn_core.log_level:
+        try:
+            logging_config["root"]["level"] = manager.settings.visyn_core.log_level
+        except KeyError:
+            logging.warn("You have set visyn_core.log_level, but no root logger is defined in visyn_core.logging")
 
     logging.config.dictConfig(logging_config)
 

--- a/visyn_core/server/visyn_server.py
+++ b/visyn_core/server/visyn_server.py
@@ -42,7 +42,14 @@ def create_visyn_server(
         workspace_config["visyn_core"] = workspace_config["tdp_core"]
 
     manager.settings = GlobalSettings(**workspace_config)
-    logging.config.dictConfig(manager.settings.visyn_core.logging)
+
+    # Initialize the logging
+    logging_config = manager.settings.visyn_core.logging
+
+    if manager.settings.visyn_core.logging_level:
+        logging_config["root"]["level"] = manager.settings.visyn_core.logging_level
+
+    logging.config.dictConfig(logging_config)
 
     # Filter out the metrics endpoint from the access log
     class EndpointFilter(logging.Filter):

--- a/visyn_core/settings/model.py
+++ b/visyn_core/settings/model.py
@@ -168,10 +168,10 @@ class VisynCoreSettings(BaseModel):
     # TODO: Proper typing. This is 1:1 passed to the logging.config.dictConfig(...).
     logging: dict = Field(default_logging_dict)
 
-    logging_level: str | None = None
+    log_level: str | None = None
     """
     Set the log level here to `DEBUG`, `INFO`, etc. if you only want to override the logging level.
-    Otherwise you must override the whol logging config of the root logger in `visyn_core.logging.root.level`.
+    Otherwise you must override the whole logging config of the root logger in `visyn_core.logging.root.level`.
     """
 
     # visyn_core

--- a/visyn_core/settings/model.py
+++ b/visyn_core/settings/model.py
@@ -168,6 +168,12 @@ class VisynCoreSettings(BaseModel):
     # TODO: Proper typing. This is 1:1 passed to the logging.config.dictConfig(...).
     logging: dict = Field(default_logging_dict)
 
+    logging_level: str | None = None
+    """
+    Set the log level here to `DEBUG`, `INFO`, etc. if you only want to override the logging level.
+    Otherwise you must override the whol logging config of the root logger in `visyn_core.logging.root.level`.
+    """
+
     # visyn_core
     migrations: DBMigrationSettings = DBMigrationSettings()
 

--- a/visyn_core/tests/test_settings.py
+++ b/visyn_core/tests/test_settings.py
@@ -1,9 +1,11 @@
+import logging
 import os
 from unittest import mock
 
 from starlette.testclient import TestClient
 
 from visyn_core import manager
+from visyn_core.server.visyn_server import create_visyn_server
 from visyn_core.settings.model import GlobalSettings
 
 
@@ -41,6 +43,24 @@ def test_env_substitution():
             env_settings.get_nested("visyn_core.logging.version") == "2"
         )  # Note that this is a string, as it cannot infer the type of Dict
         assert env_settings.get_nested("visyn_core.logging.root.level") == "DEBUG"
+
+
+def test_server_start():
+    # By default, the logging level is INFO
+    assert logging.getLogger().level == logging.INFO
+
+    with mock.patch.dict(
+        os.environ,
+        {
+            "visyn_core__log_level": "DEBUG",
+        },
+        clear=True,
+    ):
+        # Create a new server with the new settings
+        create_visyn_server()
+
+        # Assert the logging level is now DEBUG
+        assert logging.getLogger().level == logging.DEBUG
 
 
 def test_client_config(client: TestClient):


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [ ] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [ ] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Set the log level via `VISYN_CORE__LOG_LEVEL` to `DEBUG`, `INFO`, etc. if you only want to override the logging level.
- Otherwise you must override the whole logging config of the root logger in `visyn_core.logging.root.level`

### Screenshots


### Additional notes for the reviewer(s)

----
Thanks for creating this pull request 🤗
