### PR TITLE
fix: typing error for `context` in view plugin

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,15 +1,22 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Python: Module",
-            "type": "python",
-            "request": "launch",
-            "module": "visyn_core",
-            "justMyCode": false
-        }
-    ]
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch Chrome",
+      "request": "launch",
+      "type": "chrome",
+      "url": "http://localhost:8080",
+      "webRoot": "${workspaceFolder}"
+    },
+    {
+      "name": "Python: Module",
+      "type": "python",
+      "request": "launch",
+      "module": "visyn_core",
+      "justMyCode": false
+    }
+  ]
 }

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ruff = ruff $(pkg_src) setup.py --line-length 140 --select E,W,F,N,I,C,B,UP,PT,S
 
 .PHONY: start  ## Start the development server
 start:
-	python $(pkg_src)
+	python -m $(pkg_src)
 
 .PHONY: all  ## Perform the most common development-time rules
 all: format lint test

--- a/src/views/visyn/demo/VisynDemoView.tsx
+++ b/src/views/visyn/demo/VisynDemoView.tsx
@@ -150,9 +150,7 @@ export function VisynDemoViewHeader({ parameters, selection, onParametersChanged
   );
 }
 
-export function VisynDemoViewContext({ children }: DemoVisynViewPluginType['props']) {
-  return children;
-}
+export const VisynDemoViewContext = ({ children }: DemoVisynViewPluginType['props']) => children as React.ReactElement;
 
 export function createVisynDemoView(): DemoVisynViewPluginType['definition'] {
   return {
@@ -162,9 +160,9 @@ export function createVisynDemoView(): DemoVisynViewPluginType['definition'] {
       config: null,
       dataLength: 100,
     },
-    view: VisynDemoView,
+    context: VisynDemoViewContext,
     header: VisynDemoViewHeader,
     tab: VisynDemoViewSidebar,
-    context: VisynDemoViewContext,
+    view: VisynDemoView,
   };
 }

--- a/src/views/visyn/interfaces.ts
+++ b/src/views/visyn/interfaces.ts
@@ -52,7 +52,10 @@ type VisynViewComponents<Props extends object> = {
   /**
    * Optional context component of this visyn view plugin. This component wraps all of the above and allows to provide context values (i.e. via React.createContext).
    */
-  context?: React.LazyExoticComponent<React.ComponentType<Props & { children: React.ReactNode }>> | React.ComponentType<Props & { children: React.ReactNode }>;
+  context?:
+    | React.LazyExoticComponent<React.ComponentType<Props & { children: React.ReactNode }>>
+    | React.ComponentType<Props & { children: React.ReactNode }>
+    | React.ReactElement<unknown, string | React.JSXElementConstructor<unknown>>;
 };
 
 type BaseVisynViewDesc<Type extends string, Param extends Record<string, unknown>> = IBaseViewPluginDesc & {
@@ -125,7 +128,7 @@ export interface DefineVisynViewPlugin<
   /**
    * Definition to be used as return value of the loader function of the module.
    */
-  definition: Pick<VisynViewPluginBaseType<Type, Param, Props, Desc>, 'viewType' | 'defaultParameters' | 'header' | 'view' | 'tab' | 'context'>;
+  definition: Pick<VisynViewPluginBaseType<Type, Param, Props, Desc>, 'viewType' | 'defaultParameters' | 'context' | 'header' | 'tab' | 'view'>;
   /**
    * Full plugin representing the loaded visyn view.
    */


### PR DESCRIPTION
This PR contains fix for typing error in the interfaces when `context` is added to a view plugin