### PR TITLE
feat: added ability to define multiple email fields in alb and oauth2 stores

### DIFF
--- a/src/app/login/VisynLoginMenu.tsx
+++ b/src/app/login/VisynLoginMenu.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { Alert, Modal, Stack, Title, Center, Divider, Container, LoadingOverlay, Anchor } from '@mantine/core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCircleExclamation } from '@fortawesome/free-solid-svg-icons/faCircleExclamation';
-import { appContext } from '../../base/AppContext';
 import { userSession } from '../../security/UserSession';
 import { LoginUtils } from '../../security/LoginUtils';
 import { SessionWatcher } from '../../security/watcher';
@@ -13,7 +12,7 @@ import { DefaultLoginForm, UserStoreUIMap } from './UserStoreUIMap';
 export function VisynLoginMenu({ watch = false }: { watch?: boolean }) {
   const { appName, user } = useVisynAppContext();
   const [show, setShow] = useState(false);
-  const [error, setError] = useState<string>(null);
+  const [error, setError] = useState<string | null>(null);
 
   React.useEffect(() => {
     if (watch) {
@@ -73,6 +72,7 @@ export function VisynLoginMenu({ watch = false }: { watch?: boolean }) {
               component="button"
               type="button"
               onClick={() => {
+                setError(null);
                 retryGetStores();
               }}
             >

--- a/visyn_core/settings/model.py
+++ b/visyn_core/settings/model.py
@@ -44,7 +44,7 @@ class AlbSecurityStoreSettings(BaseModel):
     enable: bool = False
     cookie_name: str | None = None
     signout_url: str | None = None
-    email_token_field: str = "email"
+    email_token_field: str | list[str] = "email"
     """
     Field in the JWT token that contains the email address of the user.
     """
@@ -76,7 +76,7 @@ class OAuth2SecurityStoreSettings(BaseModel):
     cookie_name: str | None = None
     signout_url: str | None = None
     access_token_header_name: str = "X-Forwarded-Access-Token"
-    email_token_field: str = "email"
+    email_token_field: str | list[str] = "email"
 
 
 class NoSecurityStoreSettings(BaseModel):

--- a/visyn_core/settings/model.py
+++ b/visyn_core/settings/model.py
@@ -1,8 +1,8 @@
 import contextlib
-import json
 from typing import Any, Literal
 
-from pydantic import AnyHttpUrl, BaseModel, BaseSettings, Extra, Field, validator
+from pydantic import AnyHttpUrl, BaseConfig, BaseModel, BaseSettings, Extra, Field
+from pydantic.env_settings import EnvSettingsSource, SettingsSourceCallable
 
 from .constants import default_logging_dict
 
@@ -44,7 +44,7 @@ class AlbSecurityStoreSettings(BaseModel):
     enable: bool = False
     cookie_name: str | None = None
     signout_url: str | None = None
-    email_token_field: str | list[str] = "email"
+    email_token_field: str | list[str] = ["email"]
     """
     Field in the JWT token that contains the email address of the user.
     """
@@ -76,7 +76,7 @@ class OAuth2SecurityStoreSettings(BaseModel):
     cookie_name: str | None = None
     signout_url: str | None = None
     access_token_header_name: str = "X-Forwarded-Access-Token"
-    email_token_field: str | list[str] = "email"
+    email_token_field: str | list[str] = ["email"]
 
 
 class NoSecurityStoreSettings(BaseModel):
@@ -109,15 +109,6 @@ class BaseExporterTelemetrySettings(BaseModel):
     headers: dict[str, str] | None = None
     timeout: int | None = None
     kwargs: dict[str, Any] = {}
-
-    @validator("headers", pre=True)
-    def json_decode_headers(cls, v):  # NOQA N805
-        # Manually parse JSON strings if they are coming from the env via `VISYN_CORE__...='{"...": ...}'`.
-        # See https://github.com/pydantic/pydantic/issues/831 for details.
-        if isinstance(v, str):
-            with contextlib.suppress(ValueError):
-                return json.loads(v)
-        return v
 
 
 class MetricsExporterTelemetrySettings(BaseExporterTelemetrySettings):
@@ -211,15 +202,6 @@ class VisynCoreSettings(BaseModel):
     client_config: dict[str, Any] | None = None
     """Client config to be loaded via /api/v1/visyn/clientConfig"""
 
-    @validator("client_config", pre=True)
-    def json_decode_client_config(cls, v):  # NOQA N805
-        # Manually parse JSON strings if they are coming from the env via `VISYN_CORE__CLIENT_CONFIG='{"...": ...}'`.
-        # See https://github.com/pydantic/pydantic/issues/831 for details.
-        if isinstance(v, str):
-            with contextlib.suppress(ValueError):
-                return json.loads(v)
-        return v
-
 
 class GlobalSettings(BaseSettings):
     env: Literal["development", "production"] = "production"
@@ -255,6 +237,54 @@ class GlobalSettings(BaseSettings):
             dic = dic.get(key, None) if dic else None
         return dic if dic is not None else default
 
-    class Config:
+    class Config(BaseConfig):
         extra = Extra.allow
         env_nested_delimiter = "__"
+
+        @classmethod
+        def customise_sources(
+            cls,
+            init_settings: SettingsSourceCallable,
+            env_settings: EnvSettingsSource,
+            file_secret_settings: SettingsSourceCallable,
+        ) -> tuple[SettingsSourceCallable, ...]:
+            class EnvSettingsSourceWithJSON(EnvSettingsSource):
+                def __init__(self, *args, **kwargs):
+                    super().__init__(*args, **kwargs)
+                    """
+                    String vars that end with this suffix are not converted to JSON.
+                    """
+                    self.as_string_suffix = "_as_string"
+
+                def explode_env_vars(self, *args, **kwargs) -> dict[str, Any]:
+                    """
+                    This may be hacky, but it allows us to load JSON strings from the environment variables, even for deeply nested models.
+                    The original explode_env_vars simply stores the values as strings, and does not load them as JSON.
+                    Here, we patch it and iterate over all values, and try to load them as JSON.
+                    TODO: This may have one negative side effect: what if my value is typed as a string, but we now convert it to a dict?
+                    You can suffix the variable with `_as_string` to prevent this.
+                    """
+                    exploded = super().explode_env_vars(*args, **kwargs)
+
+                    def str_to_dict(d: dict[str, Any]):
+                        for k in list(d.keys()):
+                            if isinstance(d[k], dict):
+                                str_to_dict(d[k])
+                            elif isinstance(d[k], str):
+                                if k.lower().endswith(self.as_string_suffix):
+                                    # If the value ends with the suffix, add the string value without the suffix to the dict.
+                                    d[k.lower().removesuffix(self.as_string_suffix)] = d[k]
+                                else:
+                                    # Otherwise, try to load the value as JSON.
+                                    with contextlib.suppress(ValueError):
+                                        d[k] = cls.json_loads(d[k])
+                        return d
+
+                    return str_to_dict(exploded)
+
+            return (
+                init_settings,
+                # Instead of the default EnvSettingsSource, use our custom one.
+                EnvSettingsSourceWithJSON(**{s: getattr(env_settings, s) for s in env_settings.__slots__}),
+                file_secret_settings,
+            )

--- a/visyn_core/tests/test_security_login.py
+++ b/visyn_core/tests/test_security_login.py
@@ -120,6 +120,7 @@ def test_jwt_token_location(client: TestClient):
 def test_alb_security_store(client: TestClient):
     # Add some basic configuration
     manager.settings.visyn_core.security.store.alb_security_store.enable = True
+    manager.settings.visyn_core.security.store.alb_security_store.email_token_field = ["field1", "field2", "email"]
     manager.settings.visyn_core.security.store.alb_security_store.decode_options = {"verify_signature": False}
     manager.settings.visyn_core.security.store.alb_security_store.cookie_name = "TestCookie"
     manager.settings.visyn_core.security.store.alb_security_store.signout_url = "http://localhost/logout"
@@ -149,6 +150,10 @@ def test_alb_security_store(client: TestClient):
     response = client.post("/logout", headers=headers)
     assert response.status_code == 200
     assert response.json()["redirect"] == "http://localhost/logout"
+
+    # Test if we are not logged in if we use invalid fields
+    store.email_token_fields = ["field1", "field2"]
+    assert client.get("/loggedinas", headers=headers).json() == '"not_yet_logged_in"'
 
 
 def test_oauth2_security_store(client: TestClient):


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [ ] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [x] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Sometimes, tokens look different across users, so defining an ordered array of fields to look in allows supporting multiple token layouts.
- Changed the way how env variables are loaded by default: now, all string values will be parsed as json (if possible). To avoid this, simply name the env variable (not the setting!) `..._as_string`. This will disable the json parsing.

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
