### PR TITLE
Revert "deps: pin @types/react to 18.2.31"

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "@mantine/hooks": "~6.0.19",
     "@mantine/modals": "~6.0.19",
     "@mantine/notifications": "~6.0.19",
+    "@mantine/styles": "~6.0.19",
     "@types/d3-hexbin": "^0.2.3",
     "@types/d3v7": "npm:@types/d3@^7.4.0",
     "@types/plotly.js-dist-min": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
     "storybook-addon-swc": "^1.1.9"
   },
   "resolutions": {
-    "@types/react": "18.2.31",
+    "@types/react": "~18.2.0",
     "@types/react-dom": "~18.2.0",
     "react": "~18.2.0",
     "react-dom": "~18.2.0"


### PR DESCRIPTION
Reverts datavisyn/visyn_core#103, because the breaking change in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67132 is reverted as well.