### PR TITLE
feature: prevent csv injection in xlsx export

### DIFF
--- a/visyn_core/xlsx.py
+++ b/visyn_core/xlsx.py
@@ -98,14 +98,10 @@ def _json2xlsx():
     data: dict = request.json  # type: ignore
     wb = Workbook(write_only=True)
 
-    # Not sure if we should disable calculation to avoid CSV injection
-    # wb.calculation.calcMode = "manual"
-    # wb.calculation.fullCalcOnLoad = False
-
     bold = Font(bold=True)
 
     def _escape(v):
-        if isinstance(v, str) and v and v[0] in ["+", "-", "@", "="] and len(v) > 1:
+        if isinstance(v, str) and v.startswith(("+", "-", "@", "=", "DDE")):
             _log.warning("Escaping possible CSV injection: %s", v)
             return f"'{v}"
         return v

--- a/visyn_core/xlsx.py
+++ b/visyn_core/xlsx.py
@@ -98,9 +98,20 @@ def _json2xlsx():
     data: dict = request.json  # type: ignore
     wb = Workbook(write_only=True)
 
+    # Not sure if we should disable calculation to avoid CSV injection
+    # wb.calculation.calcMode = "manual"
+    # wb.calculation.fullCalcOnLoad = False
+
     bold = Font(bold=True)
 
+    def _escape(v):
+        if isinstance(v, str) and v and v[0] in ["+", "-", "@", "="]:
+            _log.warning("CSV injection detected: %s", v)
+            return f"'{v}"
+        return v
+
     def to_cell(v):
+        v = _escape(v)
         # If the native value cannot be used as Excel value, used the stringified version instead.
         try:
             return WriteOnlyCell(ws, value=v)  # type: ignore

--- a/visyn_core/xlsx.py
+++ b/visyn_core/xlsx.py
@@ -105,8 +105,8 @@ def _json2xlsx():
     bold = Font(bold=True)
 
     def _escape(v):
-        if isinstance(v, str) and v and v[0] in ["+", "-", "@", "="]:
-            _log.warning("CSV injection detected: %s", v)
+        if isinstance(v, str) and v and v[0] in ["+", "-", "@", "="] and len(v) > 1:
+            _log.warning("Escaping possible CSV injection: %s", v)
             return f"'{v}"
         return v
 


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [ ] All acceptance criteria from the issue are met
- [ ] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [ ] Branch is up-to-date with the branch to be merged with, i.e., develop
- [ ] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [ ] Descriptive title for this pull request is provided (will be used for release notes later)
- [ ] Reviewer and assignees are defined
- [ ] Add type label (e.g., *bug*, *feature*) to this pull request
- [ ] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [ ] The PR is connected to the corresponding issue (via `Closes #...`)
- [ ] [Summary of changes](#summary-of-changes) is written


### Summary of changes
- escape `+`,`-`,`@`,`=` in `_json2xlsx` in order to prevent csv injection. Previously, passing formulas or DDE scripts were executed after download. A malicious user might use upload a CSV file with formulas, and other users downloading it as xlsx will then have formulas/macros evaluated (after clicking yes to many warnings...) 

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
