### PR TITLE
fix: fix storybook by wrapping all Vis in VisProvider

### DIFF
--- a/src/vis/sidebar/VisTypeSelect.tsx
+++ b/src/vis/sidebar/VisTypeSelect.tsx
@@ -24,7 +24,7 @@ const SelectItem = React.forwardRef<HTMLDivElement, ItemProps>(({ image, label, 
   </div>
 ));
 
-SelectItem.displayName = '@mantine/core/SelectItem';
+SelectItem.displayName = 'VisTypeSelectItem';
 
 export function VisTypeSelect({ callback, currentSelected }: VisTypeSelectProps) {
   const { visTypes, getVisByType } = useVisProvider();

--- a/src/vis/stories/Iris.stories.tsx
+++ b/src/vis/stories/Iris.stories.tsx
@@ -4,6 +4,7 @@ import { Vis } from '../LazyVis';
 import { EBarDirection, EBarDisplayType, EBarGroupingType } from '../bar/interfaces';
 import { BaseVisConfig, EAggregateTypes, EColumnTypes, ENumericalColorScaleType, EScatterSelectSettings, ESupportedPlotlyVis, VisColumn } from '../interfaces';
 import { EViolinOverlay } from '../violin/interfaces';
+import { VisProvider } from '../Provider';
 
 export function fetchIrisData(): VisColumn[] {
   const dataPromise = import('./irisData').then((m) =>
@@ -93,7 +94,9 @@ const Template: ComponentStory<typeof Vis> = (args) => {
   return (
     <div style={{ height: '100vh', width: '100%', display: 'flex', justifyContent: 'center', alignContent: 'center', flexWrap: 'wrap' }}>
       <div style={{ width: '70%', height: '80%' }}>
-        <Vis {...args} columns={columns} selected={selection} selectionCallback={setSelection} />
+        <VisProvider>
+          <Vis {...args} columns={columns} selected={selection} selectionCallback={setSelection} />
+        </VisProvider>
       </div>
     </div>
   );

--- a/src/vis/stories/Vis/Bar/BarRandom.stories.tsx
+++ b/src/vis/stories/Vis/Bar/BarRandom.stories.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Vis } from '../../../LazyVis';
 import { EBarDirection, EBarDisplayType, EBarGroupingType } from '../../../bar/interfaces';
 import { BaseVisConfig, EAggregateTypes, EColumnTypes, ESupportedPlotlyVis, VisColumn } from '../../../interfaces';
+import { VisProvider } from '../../../Provider';
 
 function RNG(seed) {
   const m = 2 ** 35 - 31;
@@ -121,7 +122,9 @@ const Template: ComponentStory<typeof Vis> = (args) => {
   return (
     <div style={{ height: '100vh', width: '100%', display: 'flex', justifyContent: 'center', alignContent: 'center', flexWrap: 'wrap' }}>
       <div style={{ width: '70%', height: '80%' }}>
-        <Vis {...args} columns={columns} />
+        <VisProvider>
+          <Vis {...args} columns={columns} />
+        </VisProvider>
       </div>
     </div>
   );

--- a/src/vis/stories/Vis/Correlation/CorrelationIris.stories.tsx
+++ b/src/vis/stories/Vis/Correlation/CorrelationIris.stories.tsx
@@ -4,6 +4,7 @@ import { Vis } from '../../../LazyVis';
 import { ECorrelationType } from '../../../correlation/interfaces';
 import { BaseVisConfig, EScaleType, ESupportedPlotlyVis } from '../../../interfaces';
 import { fetchIrisData } from '../../fetchIrisData';
+import { VisProvider } from '../../../Provider';
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {
@@ -24,7 +25,9 @@ const Template: ComponentStory<typeof Vis> = (args) => {
   return (
     <div style={{ height: '100vh', width: '100%', display: 'flex', justifyContent: 'center', alignContent: 'center', flexWrap: 'wrap' }}>
       <div style={{ width: '70%', height: '80%' }}>
-        <Vis {...args} columns={columns} selected={selection} selectionCallback={setSelection} />
+        <VisProvider>
+          <Vis {...args} columns={columns} selected={selection} selectionCallback={setSelection} />
+        </VisProvider>
       </div>
     </div>
   );

--- a/src/vis/stories/Vis/Heatmap/HeatmapRandom.stories.tsx
+++ b/src/vis/stories/Vis/Heatmap/HeatmapRandom.stories.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { Vis } from '../../../LazyVis';
 import { ESortTypes } from '../../../heatmap/interfaces';
 import { BaseVisConfig, EAggregateTypes, EColumnTypes, ENumericalColorScaleType, ESupportedPlotlyVis, VisColumn } from '../../../interfaces';
+import { VisProvider } from '../../../Provider';
 
 function RNG(seed) {
   const m = 2 ** 35 - 31;
@@ -127,7 +128,9 @@ const Template: ComponentStory<typeof Vis> = (args) => {
   return (
     <div style={{ height: '100vh', width: '100%', display: 'flex', justifyContent: 'center', alignContent: 'center', flexWrap: 'wrap' }}>
       <div style={{ width: '70%', height: '80%' }}>
-        <Vis {...args} selected={selected} selectionCallback={setSelected} columns={columns} />
+        <VisProvider>
+          <Vis {...args} selected={selected} selectionCallback={setSelected} columns={columns} />
+        </VisProvider>
       </div>
     </div>
   );

--- a/src/vis/stories/Vis/Hexbin/HexbinRandom.stories.tsx
+++ b/src/vis/stories/Vis/Hexbin/HexbinRandom.stories.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Vis } from '../../../LazyVis';
 import { EHexbinOptions } from '../../../hexbin/interfaces';
 import { BaseVisConfig, EColumnTypes, EScatterSelectSettings, ESupportedPlotlyVis, VisColumn } from '../../../interfaces';
+import { VisProvider } from '../../../Provider';
 
 function RNG(seed) {
   const m = 2 ** 35 - 31;
@@ -98,7 +99,9 @@ const Template: ComponentStory<typeof Vis> = (args) => {
   return (
     <div style={{ height: '100vh', width: '100%', display: 'flex', justifyContent: 'center', alignContent: 'center', flexWrap: 'wrap' }}>
       <div style={{ width: '70%', height: '80%' }}>
-        <Vis {...args} columns={columns} />
+        <VisProvider>
+          <Vis {...args} columns={columns} />
+        </VisProvider>
       </div>
     </div>
   );

--- a/src/vis/stories/Vis/Raincloud/RaincloudRandom.stories.tsx
+++ b/src/vis/stories/Vis/Raincloud/RaincloudRandom.stories.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Vis } from '../../../LazyVis';
 import { BaseVisConfig, EColumnTypes, ESupportedPlotlyVis, VisColumn } from '../../../interfaces';
 import { ECloudType, ELightningType, ERainType } from '../../../raincloud/interfaces';
+import { VisProvider } from '../../../Provider';
 
 function RNG(seed) {
   const m = 2 ** 35 - 31;
@@ -130,7 +131,9 @@ const Template: ComponentStory<typeof Vis> = (args) => {
   return (
     <div style={{ height: '100vh', width: '100%', display: 'flex', justifyContent: 'center', alignContent: 'center', flexWrap: 'wrap' }}>
       <div style={{ width: '70%', height: '80%' }}>
-        <Vis {...args} columns={columns} selected={selected} selectionCallback={setSelected} />
+        <VisProvider>
+          <Vis {...args} columns={columns} selected={selected} selectionCallback={setSelected} />
+        </VisProvider>
       </div>
     </div>
   );

--- a/src/vis/stories/Vis/Scatter/ScatterIris.stories.tsx
+++ b/src/vis/stories/Vis/Scatter/ScatterIris.stories.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { Vis } from '../../../LazyVis';
 import { BaseVisConfig, ENumericalColorScaleType, EScatterSelectSettings, ESupportedPlotlyVis } from '../../../interfaces';
 import { fetchIrisData } from '../../fetchIrisData';
+import { VisProvider } from '../../../Provider';
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {
@@ -20,7 +21,9 @@ const Template: ComponentStory<typeof Vis> = (args) => {
   return (
     <div style={{ height: '100vh', width: '100%', display: 'flex', justifyContent: 'center', alignContent: 'center', flexWrap: 'wrap' }}>
       <div style={{ width: '70%', height: '80%' }}>
-        <Vis columns={columns} selected={selection} selectionCallback={setSelection} />
+        <VisProvider>
+          <Vis columns={columns} selected={selection} selectionCallback={setSelection} />
+        </VisProvider>
       </div>
     </div>
   );

--- a/src/vis/stories/Vis/Scatter/ScatterRandom.stories.tsx
+++ b/src/vis/stories/Vis/Scatter/ScatterRandom.stories.tsx
@@ -2,6 +2,7 @@ import { ComponentStory } from '@storybook/react';
 import React from 'react';
 import { Vis } from '../../../LazyVis';
 import { BaseVisConfig, EColumnTypes, ENumericalColorScaleType, EScatterSelectSettings, ESupportedPlotlyVis, VisColumn } from '../../../interfaces';
+import { VisProvider } from '../../../Provider';
 
 function RNG(seed) {
   const m = 2 ** 35 - 31;
@@ -109,7 +110,9 @@ const Template: ComponentStory<typeof Vis> = (args) => {
   return (
     <div style={{ height: '100vh', width: '100%', display: 'flex', justifyContent: 'center', alignContent: 'center', flexWrap: 'wrap' }}>
       <div style={{ width: '70%', height: '80%' }}>
-        <Vis {...args} selected={selected} selectionCallback={setSelected} columns={columns} />
+        <VisProvider>
+          <Vis {...args} selected={selected} selectionCallback={setSelected} columns={columns} />
+        </VisProvider>
       </div>
     </div>
   );

--- a/src/vis/stories/Vis/Violin/ViolinIris.stories.tsx
+++ b/src/vis/stories/Vis/Violin/ViolinIris.stories.tsx
@@ -4,6 +4,7 @@ import { Vis } from '../../../LazyVis';
 import { BaseVisConfig, ESupportedPlotlyVis } from '../../../interfaces';
 import { EViolinOverlay } from '../../../violin/interfaces';
 import { fetchIrisData } from '../../fetchIrisData';
+import { VisProvider } from '../../../Provider';
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {
@@ -19,7 +20,9 @@ const Template: ComponentStory<typeof Vis> = (args) => {
   return (
     <div style={{ height: '100vh', width: '100%', display: 'flex', justifyContent: 'center', alignContent: 'center', flexWrap: 'wrap' }}>
       <div style={{ width: '70%', height: '80%' }}>
-        <Vis {...args} columns={columns} />
+        <VisProvider>
+          <Vis {...args} columns={columns} />
+        </VisProvider>
       </div>
     </div>
   );


### PR DESCRIPTION
Closes https://github.com/datavisyn/visyn_core/issues/109

### Developer Checklist (Definition of Done)

**Issue**

- [ ] All acceptance criteria from the issue are met
- [ ] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [ ] Branch is up-to-date with the branch to be merged with, i.e., develop
- [ ] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [ ] Descriptive title for this pull request is provided (will be used for release notes later)
- [ ] Reviewer and assignees are defined
- [ ] Add type label (e.g., *bug*, *feature*) to this pull request
- [ ] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [ ] The PR is connected to the corresponding issue (via `Closes #...`)
- [ ] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Fixes storybook by wrapping all Vis in VisProvider (this is now necessary and usually done automatically via VisynApp).
- Also, changed the displayName for the SelectItem as the `@` broke the storybook build (for some reason...)

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
