### PR TITLE
Extended ISingleScoreResult to except column desc directly

### DIFF
--- a/src/ranking/overrides/DatavisynTaggle.tsx
+++ b/src/ranking/overrides/DatavisynTaggle.tsx
@@ -43,12 +43,15 @@ export class DatavisynTaggle<T extends DataProvider = LocalDataProvider> extends
       throw new Error('No ranking found');
     }
 
-    return castArray(desc).map(({ data, builder }) => {
-      const colDesc = builder.build(data.map((d) => ({ [(builder as any).desc.column]: d }))) as IScoreColumnDesc<unknown>;
+    return castArray(desc).map((score) => {
+      const colDesc =
+        'builder' in score
+          ? (score.builder.build(score.data.map((d) => ({ [(score.builder as any).desc.column]: d }))) as IScoreColumnDesc<unknown>)
+          : (score.desc as IScoreColumnDesc<unknown>);
 
       // Patch the accessor and add the scoreData directly in the column
+      colDesc.scoreData = score.data;
       colDesc.accessor = (row, descRef) => descRef.scoreData[row.i];
-      colDesc.scoreData = data;
 
       const col = this.data.create(colDesc);
 

--- a/src/ranking/score/interfaces.ts
+++ b/src/ranking/score/interfaces.ts
@@ -3,16 +3,25 @@ import { ColumnBuilder, IValueColumnDesc, IDataRow } from 'lineupjs';
 /**
  * A single score result
  */
-export interface ISingleScoreResult {
+export type ISingleScoreResult = {
   /**
    * The data to be used for the score column
    */
   data: unknown[];
-  /**
-   * The lineup builder object to be used for the score column
-   */
-  builder: ColumnBuilder<IValueColumnDesc<unknown>>;
-}
+} & (
+  | {
+      /**
+       * The lineup builder object to be used for the score column
+       */
+      builder: ColumnBuilder<IValueColumnDesc<unknown>>;
+    }
+  | {
+      /**
+       * The lineup column desc to be used for the score column
+       */
+      desc: IValueColumnDesc<unknown>;
+    }
+);
 
 export type IScoreResult = ISingleScoreResult | ISingleScoreResult[];
 


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Allows directly passing a desc instead of a builder for scores. This is useful if you already have a predefined desc that you want to use.

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
