### PR TITLE
fix: hide filter if no callback is provided

### DIFF
--- a/src/vis/EagerVis.tsx
+++ b/src/vis/EagerVis.tsx
@@ -130,7 +130,7 @@ export function EagerVis({
   colors = null,
   shapes = DEFAULT_SHAPES,
   selectionCallback = () => null,
-  filterCallback = () => null,
+  filterCallback,
   setExternalConfig = () => null,
   closeCallback = () => null,
   showCloseButton = false,
@@ -209,33 +209,33 @@ export function EagerVis({
     externalConfig
       ? { consistent: null, current: externalConfig }
       : columns.filter((c) => c.type === EColumnTypes.NUMERICAL).length > 1
-      ? {
-          consistent: null,
-          current: {
-            type: ESupportedPlotlyVis.SCATTER,
-            numColumnsSelected: [],
-            color: null,
-            numColorScaleType: ENumericalColorScaleType.SEQUENTIAL,
-            shape: null,
-            dragMode: EScatterSelectSettings.RECTANGLE,
-            alphaSliderVal: 0.5,
-          } as BaseVisConfig,
-        }
-      : {
-          consistent: null,
-          current: {
-            type: ESupportedPlotlyVis.BAR,
-            multiples: null,
-            group: null,
-            direction: EBarDirection.HORIZONTAL,
-            display: EBarDisplayType.ABSOLUTE,
-            groupType: EBarGroupingType.STACK,
-            numColumnsSelected: [],
-            catColumnSelected: null,
-            aggregateColumn: null,
-            aggregateType: EAggregateTypes.COUNT,
-          } as BaseVisConfig,
-        },
+        ? {
+            consistent: null,
+            current: {
+              type: ESupportedPlotlyVis.SCATTER,
+              numColumnsSelected: [],
+              color: null,
+              numColorScaleType: ENumericalColorScaleType.SEQUENTIAL,
+              shape: null,
+              dragMode: EScatterSelectSettings.RECTANGLE,
+              alphaSliderVal: 0.5,
+            } as BaseVisConfig,
+          }
+        : {
+            consistent: null,
+            current: {
+              type: ESupportedPlotlyVis.BAR,
+              multiples: null,
+              group: null,
+              direction: EBarDirection.HORIZONTAL,
+              display: EBarDisplayType.ABSOLUTE,
+              groupType: EBarGroupingType.STACK,
+              numColumnsSelected: [],
+              catColumnSelected: null,
+              aggregateColumn: null,
+              aggregateType: EAggregateTypes.COUNT,
+            } as BaseVisConfig,
+          },
   );
 
   const setExternalConfigRef = useSyncedRef(setExternalConfig);

--- a/src/vis/VisSidebar.tsx
+++ b/src/vis/VisSidebar.tsx
@@ -4,7 +4,7 @@ import { ICommonVisSideBarProps } from './interfaces';
 
 export function VisSidebar({
   columns,
-  filterCallback = () => null,
+  filterCallback,
   optionsConfig,
   config = null,
   setConfig = null,

--- a/src/vis/bar/BarVisSidebar.tsx
+++ b/src/vis/bar/BarVisSidebar.tsx
@@ -96,15 +96,8 @@ export function BarVisSidebar({
             <BarDirectionButtons callback={(direction: EBarDirection) => setConfig({ ...config, direction })} currentSelected={config.direction} />
           )
         : null}
-      {filterCallback ? (
-        mergedOptionsConfig.filter.enable ? (
-          mergedOptionsConfig.filter.customComponent ? (
-            mergedOptionsConfig.filter.customComponent
-          ) : null
-        ) : (
-          <FilterButtons callback={filterCallback} />
-        )
-      ) : null}
+
+      {filterCallback && mergedOptionsConfig.filter.enable ? mergedOptionsConfig.filter.customComponent || <FilterButtons callback={filterCallback} /> : null}
     </>
   );
 }

--- a/src/vis/bar/BarVisSidebar.tsx
+++ b/src/vis/bar/BarVisSidebar.tsx
@@ -96,12 +96,14 @@ export function BarVisSidebar({
             <BarDirectionButtons callback={(direction: EBarDirection) => setConfig({ ...config, direction })} currentSelected={config.direction} />
           )
         : null}
-      {mergedOptionsConfig.filter.enable ? (
-        mergedOptionsConfig.filter.customComponent ? (
-          mergedOptionsConfig.filter.customComponent
-        ) : filterCallback ? (
+      {filterCallback ? (
+        mergedOptionsConfig.filter.enable ? (
+          mergedOptionsConfig.filter.customComponent ? (
+            mergedOptionsConfig.filter.customComponent
+          ) : null
+        ) : (
           <FilterButtons callback={filterCallback} />
-        ) : null
+        )
       ) : null}
     </>
   );

--- a/src/vis/bar/BarVisSidebar.tsx
+++ b/src/vis/bar/BarVisSidebar.tsx
@@ -10,30 +10,12 @@ import { GroupSelect } from './GroupSelect';
 import { EBarDirection, EBarDisplayType, EBarGroupingType, IBarConfig } from './interfaces';
 
 const defaultConfig = {
-  group: {
-    enable: true,
-    customComponent: null,
-  },
-  multiples: {
-    enable: true,
-    customComponent: null,
-  },
-  direction: {
-    enable: true,
-    customComponent: null,
-  },
-  filter: {
-    enable: true,
-    customComponent: null,
-  },
-  groupType: {
-    enable: true,
-    customComponent: null,
-  },
-  display: {
-    enable: true,
-    customComponent: null,
-  },
+  direction: { enable: true, customComponent: null },
+  display: { enable: true, customComponent: null },
+  filter: { enable: true, customComponent: null },
+  group: { enable: true, customComponent: null },
+  groupType: { enable: true, customComponent: null },
+  multiples: { enable: true, customComponent: null },
 };
 
 export function BarVisSidebar({
@@ -114,7 +96,13 @@ export function BarVisSidebar({
             <BarDirectionButtons callback={(direction: EBarDirection) => setConfig({ ...config, direction })} currentSelected={config.direction} />
           )
         : null}
-      {mergedOptionsConfig.filter.enable ? mergedOptionsConfig.filter.customComponent || <FilterButtons callback={filterCallback} /> : null}
+      {mergedOptionsConfig.filter.enable ? (
+        mergedOptionsConfig.filter.customComponent ? (
+          mergedOptionsConfig.filter.customComponent
+        ) : filterCallback ? (
+          <FilterButtons callback={filterCallback} />
+        ) : null
+      ) : null}
     </>
   );
 }

--- a/src/vis/scatter/ScatterVisSidebar.tsx
+++ b/src/vis/scatter/ScatterVisSidebar.tsx
@@ -68,15 +68,7 @@ export function ScatterVisSidebar({ config, optionsConfig, columns, filterCallba
         currentValue={config.alphaSliderVal}
       />
 
-      {filterCallback ? (
-        mergedOptionsConfig.filter.enable ? (
-          mergedOptionsConfig.filter.customComponent ? (
-            mergedOptionsConfig.filter.customComponent
-          ) : null
-        ) : (
-          <FilterButtons callback={filterCallback} />
-        )
-      ) : null}
+      {filterCallback && mergedOptionsConfig.filter.enable ? mergedOptionsConfig.filter.customComponent || <FilterButtons callback={filterCallback} /> : null}
     </>
   );
 }

--- a/src/vis/scatter/ScatterVisSidebar.tsx
+++ b/src/vis/scatter/ScatterVisSidebar.tsx
@@ -67,7 +67,16 @@ export function ScatterVisSidebar({ config, optionsConfig, columns, filterCallba
         }}
         currentValue={config.alphaSliderVal}
       />
-      {mergedOptionsConfig.filter.enable ? mergedOptionsConfig.filter.customComponent || <FilterButtons callback={filterCallback} /> : null}
+
+      {filterCallback ? (
+        mergedOptionsConfig.filter.enable ? (
+          mergedOptionsConfig.filter.customComponent ? (
+            mergedOptionsConfig.filter.customComponent
+          ) : null
+        ) : (
+          <FilterButtons callback={filterCallback} />
+        )
+      ) : null}
     </>
   );
 }

--- a/src/vis/scatter/ScatterVisSidebar.tsx
+++ b/src/vis/scatter/ScatterVisSidebar.tsx
@@ -24,7 +24,7 @@ const defaultConfig = {
   },
 };
 
-export function ScatterVisSidebar({ config, optionsConfig, columns, filterCallback = () => null, setConfig }: ICommonVisSideBarProps<IScatterConfig>) {
+export function ScatterVisSidebar({ config, optionsConfig, columns, filterCallback, setConfig }: ICommonVisSideBarProps<IScatterConfig>) {
   const mergedOptionsConfig = useMemo(() => {
     return merge({}, defaultConfig, optionsConfig);
   }, [optionsConfig]);

--- a/src/vis/stories/Vis/Scatter/ScatterIris.stories.tsx
+++ b/src/vis/stories/Vis/Scatter/ScatterIris.stories.tsx
@@ -22,7 +22,7 @@ const Template: ComponentStory<typeof Vis> = (args) => {
     <VisProvider>
       <div style={{ height: '100vh', width: '100%', display: 'flex', justifyContent: 'center', alignContent: 'center', flexWrap: 'wrap' }}>
         <div style={{ width: '70%', height: '80%' }}>
-          <Vis columns={columns} selected={selection} selectionCallback={setSelection} />
+          <Vis columns={columns} {...args} />
         </div>
       </div>
     </VisProvider>
@@ -53,6 +53,10 @@ Basic.args = {
     dragMode: EScatterSelectSettings.RECTANGLE,
     alphaSliderVal: 1,
   } as BaseVisConfig,
+
+  filterCallback: (option) => {
+    console.log({ option });
+  },
 };
 
 export const ColorByCategory: typeof Template = Template.bind({}) as typeof Template;

--- a/src/vis/violin/ViolinVisSidebar.tsx
+++ b/src/vis/violin/ViolinVisSidebar.tsx
@@ -54,15 +54,7 @@ export function ViolinVisSidebar({
           )
         : null}
 
-      {filterCallback ? (
-        mergedOptionsConfig.filter.enable ? (
-          mergedOptionsConfig.filter.customComponent ? (
-            mergedOptionsConfig.filter.customComponent
-          ) : null
-        ) : (
-          <FilterButtons callback={filterCallback} />
-        )
-      ) : null}
+      {filterCallback && mergedOptionsConfig.filter.enable ? mergedOptionsConfig.filter.customComponent || <FilterButtons callback={filterCallback} /> : null}
     </>
   );
 }

--- a/src/vis/violin/ViolinVisSidebar.tsx
+++ b/src/vis/violin/ViolinVisSidebar.tsx
@@ -54,7 +54,15 @@ export function ViolinVisSidebar({
           )
         : null}
 
-      {mergedOptionsConfig.filter.enable ? mergedOptionsConfig.filter.customComponent || <FilterButtons callback={filterCallback} /> : null}
+      {filterCallback ? (
+        mergedOptionsConfig.filter.enable ? (
+          mergedOptionsConfig.filter.customComponent ? (
+            mergedOptionsConfig.filter.customComponent
+          ) : null
+        ) : (
+          <FilterButtons callback={filterCallback} />
+        )
+      ) : null}
     </>
   );
 }


### PR DESCRIPTION
Closes #114 

### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [x] Requires UI/UX/Vis review
  - [x] Reviewer(s) are notified @dvdanielamoitzi 
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- The filter buttons are not visible anymore for the components which do not have a filter callback

### Screenshots

![image](https://github.com/datavisyn/visyn_core/assets/115616380/069072eb-6358-4b54-9559-96582b7719fd)


### Additional notes for the reviewer(s)

-  N/A
Thanks for creating this pull request 🤗
