### PR TITLE
feat: add `withCSSVariables` to default Mantine provider props

### DIFF
--- a/src/app/constants.tsx
+++ b/src/app/constants.tsx
@@ -2,6 +2,7 @@ import { MantineProviderProps } from '@mantine/core';
 
 export const DEFAULT_MANTINE_PROVIDER_PROPS: Omit<MantineProviderProps, 'children'> = {
   withNormalizeCSS: true,
+  withCSSVariables: true,
   withGlobalStyles: true,
   theme: {
     fontFamily: 'Roboto, sans-serif',


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [ ] All acceptance criteria from the issue are met
- [ ] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [ ] Branch is up-to-date with the branch to be merged with, i.e., develop
- [ ] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [ ] Descriptive title for this pull request is provided (will be used for release notes later)
- [ ] Reviewer and assignees are defined
- [ ] Add type label (e.g., *bug*, *feature*) to this pull request
- [ ] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [ ] The PR is connected to the corresponding issue (via `Closes #...`)
- [ ] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- As a preparation for Mantine 7, start exposing the Mantine CSS variables to use them for styling.

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
