### PR TITLE
feat: implement heatmap multiples

### DIFF
--- a/src/vis/heatmap/Heatmap.tsx
+++ b/src/vis/heatmap/Heatmap.tsx
@@ -135,29 +135,29 @@ export function Heatmap({
                 : d3.extent(groupedVals, (d) => d.aggregateVal as number),
             )
         : config?.numColorScaleType === ENumericalColorScaleType.DIVERGENT
-        ? d3
-            .scaleSequential<string, string>(
-              d3.piecewise(
-                d3.interpolateRgb.gamma(2.2),
-                [
-                  '#003367',
-                  '#16518a',
-                  '#2e72ae',
-                  '#5093cd',
-                  '#77b5ea',
-                  '#aad7fd',
-                  '#F1F3F5',
-                  '#fac7a9',
-                  '#f99761',
-                  '#e06d3b',
-                  '#c2451a',
-                  '#99230d',
-                  '#6f0000',
-                ].reverse(),
-              ),
-            )
-            .domain(d3.extent(groupedVals, (d) => d.aggregateVal as number))
-        : null;
+          ? d3
+              .scaleSequential<string, string>(
+                d3.piecewise(
+                  d3.interpolateRgb.gamma(2.2),
+                  [
+                    '#003367',
+                    '#16518a',
+                    '#2e72ae',
+                    '#5093cd',
+                    '#77b5ea',
+                    '#aad7fd',
+                    '#F1F3F5',
+                    '#fac7a9',
+                    '#f99761',
+                    '#e06d3b',
+                    '#c2451a',
+                    '#99230d',
+                    '#6f0000',
+                  ].reverse(),
+                ),
+              )
+              .domain(d3.extent(groupedVals, (d) => d.aggregateVal as number))
+          : null;
 
     const extGroupedVals = groupedVals.map((gV) => ({
       ...gV,
@@ -228,6 +228,7 @@ export function Heatmap({
           width={width - margin.left - margin.right}
           scale={colorScale}
           height={20}
+          canvasIdentifier={`${column1.info.id}-${column2.info.id}`}
           range={[...colorScale.domain()]}
           title={`${config.aggregateType} ${config.aggregateType === EAggregateTypes.COUNT ? '' : config.aggregateColumn.name}`}
         />
@@ -243,10 +244,10 @@ export function Heatmap({
                 config.ySortedBy === ESortTypes.CAT_ASC
                   ? ESortTypes.CAT_DESC
                   : config.ySortedBy === ESortTypes.CAT_DESC
-                  ? ESortTypes.VAL_ASC
-                  : config.ySortedBy === ESortTypes.VAL_ASC
-                  ? ESortTypes.VAL_DESC
-                  : ESortTypes.CAT_ASC,
+                    ? ESortTypes.VAL_ASC
+                    : config.ySortedBy === ESortTypes.VAL_ASC
+                      ? ESortTypes.VAL_DESC
+                      : ESortTypes.CAT_ASC,
             })
           }
         >
@@ -258,10 +259,10 @@ export function Heatmap({
               config.ySortedBy === ESortTypes.VAL_ASC
                 ? faArrowDownShortWide
                 : config.ySortedBy === ESortTypes.VAL_DESC
-                ? faArrowDownWideShort
-                : config.ySortedBy === ESortTypes.CAT_ASC
-                ? faArrowDownAZ
-                : faArrowDownZA
+                  ? faArrowDownWideShort
+                  : config.ySortedBy === ESortTypes.CAT_ASC
+                    ? faArrowDownAZ
+                    : faArrowDownZA
             }
           />
           {column2.info.name}
@@ -294,10 +295,10 @@ export function Heatmap({
               config.xSortedBy === ESortTypes.CAT_ASC
                 ? ESortTypes.CAT_DESC
                 : config.xSortedBy === ESortTypes.CAT_DESC
-                ? ESortTypes.VAL_ASC
-                : config.xSortedBy === ESortTypes.VAL_ASC
-                ? ESortTypes.VAL_DESC
-                : ESortTypes.CAT_ASC,
+                  ? ESortTypes.VAL_ASC
+                  : config.xSortedBy === ESortTypes.VAL_ASC
+                    ? ESortTypes.VAL_DESC
+                    : ESortTypes.CAT_ASC,
           })
         }
       >
@@ -308,10 +309,10 @@ export function Heatmap({
             config.xSortedBy === ESortTypes.VAL_ASC
               ? faArrowDownShortWide
               : config.xSortedBy === ESortTypes.VAL_DESC
-              ? faArrowDownWideShort
-              : config.xSortedBy === ESortTypes.CAT_ASC
-              ? faArrowDownAZ
-              : faArrowDownZA
+                ? faArrowDownWideShort
+                : config.xSortedBy === ESortTypes.CAT_ASC
+                  ? faArrowDownAZ
+                  : faArrowDownZA
           }
         />
         {column1.info.name}

--- a/src/vis/heatmap/HeatmapGrid.tsx
+++ b/src/vis/heatmap/HeatmapGrid.tsx
@@ -1,11 +1,11 @@
-import { Loader, Stack } from '@mantine/core';
-import * as React from 'react';
+import { Box, Loader, Stack } from '@mantine/core';
+import React, { useMemo } from 'react';
 import { useAsync } from '../../hooks/useAsync';
 import { InvalidCols } from '../general/InvalidCols';
 import { VisColumn } from '../interfaces';
 import { Heatmap } from './Heatmap';
 import { IHeatmapConfig } from './interfaces';
-import { getHeatmapData } from './utils';
+import { getHeatmapData, setsOfTwo } from './utils';
 
 export function HeatmapGrid({
   config,
@@ -21,9 +21,9 @@ export function HeatmapGrid({
   selected?: { [key: string]: boolean };
 }) {
   const { value: allColumns, status } = useAsync(getHeatmapData, [columns, config.catColumnsSelected, config.aggregateColumn]);
-  const hasAtLeast2CatCols = allColumns?.catColumn && allColumns?.catColumn?.length > 1;
+  const hasAtLeast2CatCols = useMemo(() => allColumns?.catColumn && allColumns?.catColumn?.length > 1, [allColumns?.catColumn]);
 
-  const margin = React.useMemo(() => {
+  const margin = useMemo(() => {
     return {
       top: 10,
       right: 20,
@@ -32,6 +32,10 @@ export function HeatmapGrid({
     };
   }, []);
 
+  const heatmapMultiples = useMemo(() => {
+    return setsOfTwo(hasAtLeast2CatCols ? allColumns?.catColumn : []) as Awaited<ReturnType<typeof getHeatmapData>>['catColumn'][];
+  }, [allColumns?.catColumn, hasAtLeast2CatCols]);
+
   return (
     <Stack align="center" justify="center" sx={{ width: '100%', height: '100%' }} p="sm">
       {status === 'pending' ? (
@@ -39,16 +43,29 @@ export function HeatmapGrid({
       ) : !hasAtLeast2CatCols ? (
         <InvalidCols headerMessage="Invalid settings" bodyMessage="To create a heatmap chart, select at least 2 categorical columns." />
       ) : (
-        <Heatmap
-          column1={allColumns.catColumn[0]}
-          column2={allColumns.catColumn[1]}
-          aggregateColumn={allColumns.aggregateColumn}
-          margin={margin}
-          config={config}
-          selected={selected}
-          setExternalConfig={setExternalConfig}
-          selectionCallback={selectionCallback}
-        />
+        <Box
+          style={{
+            display: 'grid',
+            gridTemplateColumns: `repeat(${heatmapMultiples.length === 1 ? 1 : heatmapMultiples.length - 1}, 1fr)`,
+            gridTemplateRows: `repeat(${heatmapMultiples.length === 1 ? 1 : heatmapMultiples.length - 1}, 1fr)`,
+            width: '100%',
+            height: '100%',
+          }}
+        >
+          {heatmapMultiples.map(([column1, column2]) => (
+            <Heatmap
+              key={`${column1.info.id}-${column2.info.id}`}
+              column1={column1}
+              column2={column2}
+              aggregateColumn={allColumns.aggregateColumn}
+              margin={margin}
+              config={config}
+              selected={selected}
+              setExternalConfig={setExternalConfig}
+              selectionCallback={selectionCallback}
+            />
+          ))}
+        </Box>
       )}
     </Stack>
   );

--- a/src/vis/heatmap/utils.ts
+++ b/src/vis/heatmap/utils.ts
@@ -50,3 +50,13 @@ export async function getHeatmapData(
 
   return { catColumn, aggregateColumn };
 }
+
+export const setsOfTwo = <T = unknown>(arr: T[]) => {
+  const result: T[][] = [];
+  for (let i = 0; i < arr.length; i++) {
+    for (let j = i + 1; j < arr.length; j++) {
+      result.push([arr[i], arr[j]]);
+    }
+  }
+  return result;
+};

--- a/src/vis/legend/ColorLegend.tsx
+++ b/src/vis/legend/ColorLegend.tsx
@@ -12,6 +12,7 @@ export function ColorLegend({
   format = '.3s',
   rightMargin = 40,
   title = null,
+  canvasIdentifier = '',
 }: {
   scale: (t: number) => string;
   width?: number;
@@ -21,6 +22,7 @@ export function ColorLegend({
   format?: string;
   rightMargin?: number;
   title: string;
+  canvasIdentifier?: string;
 }) {
   const colors = d3
     .range(tickCount)
@@ -32,8 +34,10 @@ export function ColorLegend({
 
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
+  const canvasId = useMemo(() => `vertical-color-legend-canvas-${canvasIdentifier}`, [canvasIdentifier]);
+
   useEffect(() => {
-    const canvas: HTMLCanvasElement = document.getElementById('proteomicsLegendCanvas') as HTMLCanvasElement;
+    const canvas: HTMLCanvasElement = document.getElementById(canvasId) as HTMLCanvasElement;
 
     const context = canvas.getContext('2d');
     canvas.width = width;
@@ -52,7 +56,7 @@ export function ColorLegend({
       context.fillStyle = scale(t[i] + range[0]);
       context.fillRect(0, i, width, 1);
     }
-  }, [scale, width, height, range]);
+  }, [scale, width, height, range, canvasId]);
 
   const formatFunc = useMemo(() => {
     return d3.format(format);
@@ -60,7 +64,7 @@ export function ColorLegend({
 
   return (
     <Group spacing={5} noWrap style={{ width: `${width + rightMargin}px` }}>
-      <canvas id="proteomicsLegendCanvas" ref={canvasRef} />
+      <canvas id={canvasId} ref={canvasRef} />
       <Stack align="stretch" justify="space-between" style={{ height: `${height}px` }} spacing={0} ml="0">
         {colors.map((color, i) => (
           // idk why this doesnt work when i use the score as the key, tbh. The scores definitely are unique, but something to do with the 0 changing on render, idk

--- a/src/vis/legend/ColorLegendVert.tsx
+++ b/src/vis/legend/ColorLegendVert.tsx
@@ -11,6 +11,7 @@ export function ColorLegendVert({
   tickCount = 5,
   title = null,
   format = '.3s',
+  canvasIdentifier = '',
 }: {
   scale: (t: number) => string;
   width?: number;
@@ -19,6 +20,7 @@ export function ColorLegendVert({
   tickCount?: number;
   title: string;
   format?: string;
+  canvasIdentifier?: string;
 }) {
   const colors = d3
     .range(tickCount)
@@ -30,8 +32,10 @@ export function ColorLegendVert({
 
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
+  const canvasId = useMemo(() => `vertical-color-legend-canvas-${canvasIdentifier}`, [canvasIdentifier]);
+
   useEffect(() => {
-    const canvas: HTMLCanvasElement = document.getElementById('proteomicsLegendCanvas') as HTMLCanvasElement;
+    const canvas: HTMLCanvasElement = document.getElementById(canvasId) as HTMLCanvasElement;
 
     const context = canvas.getContext('2d');
     canvas.height = height;
@@ -50,7 +54,7 @@ export function ColorLegendVert({
       context.fillStyle = scale(t[i] + range[0]);
       context.fillRect(i, 0, 1, height);
     }
-  }, [scale, width, height, range]);
+  }, [scale, width, height, range, canvasId]);
 
   const formatFunc = useMemo(() => {
     return d3.format(format);
@@ -63,7 +67,7 @@ export function ColorLegendVert({
           {title}
         </Text>
       ) : null}
-      <canvas style={{ width: '100%' }} id="proteomicsLegendCanvas" ref={canvasRef} />
+      <canvas style={{ width: '100%' }} id={canvasId} ref={canvasRef} />
 
       <Group position="apart" style={{ width: `100%` }} spacing={0} ml="0">
         {colors.map((color, i) => (


### PR DESCRIPTION
Closes #112

### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [x] Requires UI/UX/Vis review
  - [x] Reviewer(s) are notified @dvdanielamoitzi 
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [ ] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Fixed behavior of heatmaps when multiple categorical columns are selected

### Screenshots
 
![image](https://github.com/datavisyn/visyn_core/assets/115616380/c79eee6c-57b8-4814-9dd4-b0d09c5c43b8)


### Additional notes for the reviewer(s)

-  The performance of the component is noticeably slow when multiple categorical columns are selected for a medium-large dataset
- There are errors in the console which refer to incorrect attributes being set to `<svg>` elements during render
- The sorting of one of the axes of a heatmap also sort the other heatmaps in sync 
- The labels do not have a good placement if multiple heatmaps are rendered