### PR TITLE
Add possibility to specify which vis types to show in the sidebar

### DIFF
--- a/src/vis/EagerVis.tsx
+++ b/src/vis/EagerVis.tsx
@@ -55,7 +55,7 @@ import { IViolinConfig } from './violin/interfaces';
 
 const DEFAULT_SHAPES = ['circle', 'square', 'triangle-up', 'star'];
 
-function registerAllVis() {
+function registerAllVis(visTypes?: string[]) {
   return [
     createVis({
       type: ESupportedPlotlyVis.SCATTER,
@@ -113,15 +113,15 @@ function registerAllVis() {
       mergeConfig: correlationMergeDefaultConfig,
       description: 'Visualizes statistical relationships between pairs of numerical variables',
     }),
-  ];
+  ].filter((v) => !visTypes || visTypes.includes(v.type));
 }
 
-export function useRegisterDefaultVis() {
+export function useRegisterDefaultVis(visTypes?: string[]) {
   const { registerVisType } = useVisProvider();
 
   React.useEffect(() => {
-    registerVisType(...registerAllVis());
-  }, [registerVisType]);
+    registerVisType(...registerAllVis(visTypes));
+  }, [registerVisType, visTypes]);
 }
 
 export function EagerVis({
@@ -141,6 +141,7 @@ export function EagerVis({
   setShowSidebar: internalSetShowSidebar,
   showSidebarDefault = false,
   scrollZoom = true,
+  visTypes,
 }: {
   /**
    * Required data columns which are displayed.
@@ -185,6 +186,10 @@ export function EagerVis({
   setShowSidebar?(show: boolean): void;
   showSidebarDefault?: boolean;
   scrollZoom?: boolean;
+  /**
+   * Optional property which enables the user to specify which vis types to show as options in the sidebar. If not specified, all vis types will be used.
+   */
+  visTypes?: string[];
 }) {
   const [showSidebar, setShowSidebar] = useUncontrolled<boolean>({
     value: internalShowSidebar,
@@ -195,7 +200,7 @@ export function EagerVis({
 
   const [ref, dimensions] = useResizeObserver();
 
-  useRegisterDefaultVis();
+  useRegisterDefaultVis(visTypes);
 
   const { getVisByType } = useVisProvider();
 


### PR DESCRIPTION
We have the requirement to hide the heatmap in the general purpose vis. This PR introduces a property "visTypes" for the <Vis /> component which enables the developer to specify which vis types to show as options in the sidebar. If not specified, all vis types will be used.

### Developer Checklist (Definition of Done)

**Issue**

- [ ] All acceptance criteria from the issue are met
- [ ] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [ ] Branch is up-to-date with the branch to be merged with, i.e., develop
- [ ] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [ ] Descriptive title for this pull request is provided (will be used for release notes later)
- [ ] Reviewer and assignees are defined
- [ ] Add type label (e.g., *bug*, *feature*) to this pull request
- [ ] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [ ] The PR is connected to the corresponding issue (via `Closes #...`)
- [ ] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- added visTypes prop to Vis component
- filtering by visTypes when registering the vis types

### Screenshots
In this example I have only passed `visTypes={[ESupportedPlotlyVis.HEATMAP]}` to the Vis component, and as you can see there are no more options in the sidebar:
![image](https://github.com/datavisyn/visyn_core/assets/57343176/664d2ca0-ee27-4e5c-bc64-89c3400d5120)


### Additional notes for the reviewer(s)
-  I'm not entirely sure if this is the way we want to do it, there would be the possibility to exclude certain vis types which might be better as newly introduced vis types would then show up by default whereas in my current approach the developer would need to add the new vistype to the visTypes props manually.


Thanks for creating this pull request 🤗
