### PR TITLE
Handle null value only columns in raincloud plot

### DIFF
--- a/src/vis/raincloud/Raincloud.tsx
+++ b/src/vis/raincloud/Raincloud.tsx
@@ -20,6 +20,7 @@ import { Circle } from './rain/Circle';
 import { DotPlot } from './rain/DotPlot';
 import { StripPlot } from './rain/StripPlot';
 import { WheatPlot } from './rain/WheatPlot';
+import { InvalidCols } from '../general/InvalidCols';
 
 const margin = {
   top: 0,
@@ -103,6 +104,8 @@ export function Raincloud({
       .rollup({ values: op.mean('values'), ids: op.array_agg('ids') });
   }, [baseTable]);
 
+  const hasData = column.resolvedValues.filter((row) => row.val !== null).length > 0;
+
   return (
     <Box ref={ref} style={{ maxWidth: '100%', maxHeight: '100%', position: 'relative', overflow: 'hidden' }}>
       <Container
@@ -120,70 +123,76 @@ export function Raincloud({
               <text textAnchor="middle" dominantBaseline="middle" x={width / 2} y={15}>
                 {column.info.name}
               </text>
-              <g>
-                {config.cloudType === ECloudType.HEATMAP ? (
-                  <Heatmap width={width} height={height / 2} config={config} numCol={column} />
-                ) : config.cloudType === ECloudType.HISTOGRAM ? (
-                  <Histogram width={width} height={height / 2} config={config} numCol={column} />
-                ) : (
-                  <SplitViolin width={width} height={height / 2} config={config} numCol={column} />
-                )}
+              {hasData ? (
+                <g>
+                  {config.cloudType === ECloudType.HEATMAP ? (
+                    <Heatmap width={width} height={height / 2} config={config} numCol={column} />
+                  ) : config.cloudType === ECloudType.HISTOGRAM ? (
+                    <Histogram width={width} height={height / 2} config={config} numCol={column} />
+                  ) : (
+                    <SplitViolin width={width} height={height / 2} config={config} numCol={column} />
+                  )}
 
-                {config.rainType === ERainType.DOTPLOT ? (
-                  <DotPlot
-                    yPos={height / 2}
-                    width={width}
-                    height={height}
-                    config={config}
-                    numCol={column}
-                    circleCallback={circlesCallback}
-                    baseTable={config.aggregateRain || column.resolvedValues.length > MAX_NON_AGGREGATED_COUNT ? aggregatedTable : baseTable}
-                  />
-                ) : config.rainType === ERainType.BEESWARM ? (
-                  <BeeSwarm
-                    baseTable={config.aggregateRain || column.resolvedValues.length > MAX_NON_AGGREGATED_COUNT ? aggregatedTable : baseTable}
-                    yPos={height / 2}
-                    width={width}
-                    height={height / 2}
-                    config={config}
-                    numCol={column}
-                    circleCallback={circlesCallback}
-                  />
-                ) : config.rainType === ERainType.WHEATPLOT ? (
-                  <WheatPlot
-                    yPos={height / 2}
-                    width={width}
-                    height={height / 2}
-                    config={config}
-                    numCol={column}
-                    circleCallback={circlesCallback}
-                    baseTable={config.aggregateRain || column.resolvedValues.length > MAX_NON_AGGREGATED_COUNT ? aggregatedTable : baseTable}
-                  />
-                ) : config.rainType === ERainType.STRIPPLOT ? (
-                  <StripPlot
-                    yPos={height / 2}
-                    width={width}
-                    height={height / 2}
-                    config={config}
-                    numCol={column}
-                    circleCallback={circlesCallback}
-                    baseTable={config.aggregateRain || column.resolvedValues.length > MAX_NON_AGGREGATED_COUNT ? aggregatedTable : baseTable}
-                  />
-                ) : null}
-                {circlesRendered}
-                {config.lightningType === ELightningType.MEAN_AND_DEV ? (
-                  <MeanAndInterval yPos={height / 2} width={width} height={height} config={config} numCol={column} baseTable={baseTable} />
-                ) : config.lightningType === ELightningType.MEAN ? (
-                  <Mean yPos={height / 2} width={width} height={height} config={config} numCol={column} baseTable={baseTable} />
-                ) : config.lightningType === ELightningType.MEDIAN_AND_DEV ? (
-                  <MedianAndInterval yPos={height / 2} width={width} height={height} config={config} numCol={column} baseTable={baseTable} />
-                ) : config.lightningType === ELightningType.BOXPLOT ? (
-                  <Boxplot yPos={height / 2} width={width} height={height} config={config} numCol={column} baseTable={baseTable} />
-                ) : null}
+                  {config.rainType === ERainType.DOTPLOT ? (
+                    <DotPlot
+                      yPos={height / 2}
+                      width={width}
+                      height={height}
+                      config={config}
+                      numCol={column}
+                      circleCallback={circlesCallback}
+                      baseTable={config.aggregateRain || column.resolvedValues.length > MAX_NON_AGGREGATED_COUNT ? aggregatedTable : baseTable}
+                    />
+                  ) : config.rainType === ERainType.BEESWARM ? (
+                    <BeeSwarm
+                      baseTable={config.aggregateRain || column.resolvedValues.length > MAX_NON_AGGREGATED_COUNT ? aggregatedTable : baseTable}
+                      yPos={height / 2}
+                      width={width}
+                      height={height / 2}
+                      config={config}
+                      numCol={column}
+                      circleCallback={circlesCallback}
+                    />
+                  ) : config.rainType === ERainType.WHEATPLOT ? (
+                    <WheatPlot
+                      yPos={height / 2}
+                      width={width}
+                      height={height / 2}
+                      config={config}
+                      numCol={column}
+                      circleCallback={circlesCallback}
+                      baseTable={config.aggregateRain || column.resolvedValues.length > MAX_NON_AGGREGATED_COUNT ? aggregatedTable : baseTable}
+                    />
+                  ) : config.rainType === ERainType.STRIPPLOT ? (
+                    <StripPlot
+                      yPos={height / 2}
+                      width={width}
+                      height={height / 2}
+                      config={config}
+                      numCol={column}
+                      circleCallback={circlesCallback}
+                      baseTable={config.aggregateRain || column.resolvedValues.length > MAX_NON_AGGREGATED_COUNT ? aggregatedTable : baseTable}
+                    />
+                  ) : null}
+                  {circlesRendered}
+                  {config.lightningType === ELightningType.MEAN_AND_DEV ? (
+                    <MeanAndInterval yPos={height / 2} width={width} height={height} config={config} numCol={column} baseTable={baseTable} />
+                  ) : config.lightningType === ELightningType.MEAN ? (
+                    <Mean yPos={height / 2} width={width} height={height} config={config} numCol={column} baseTable={baseTable} />
+                  ) : config.lightningType === ELightningType.MEDIAN_AND_DEV ? (
+                    <MedianAndInterval yPos={height / 2} width={width} height={height} config={config} numCol={column} baseTable={baseTable} />
+                  ) : config.lightningType === ELightningType.BOXPLOT ? (
+                    <Boxplot yPos={height / 2} width={width} height={height} config={config} numCol={column} baseTable={baseTable} />
+                  ) : null}
 
-                <XAxis xScale={xScale} vertPosition={height / 2} yRange={null} />
-                <Brush y={height / 2 - 20} x={margin.left} height={40} width={width - margin.left} onBrush={brushCallback} id={column.info.id} />
-              </g>
+                  <XAxis xScale={xScale} vertPosition={height / 2} yRange={null} />
+                  <Brush y={height / 2 - 20} x={margin.left} height={40} width={width - margin.left} onBrush={brushCallback} id={column.info.id} />
+                </g>
+              ) : (
+                <foreignObject width="100%" height="100%">
+                  <InvalidCols headerMessage="Invalid data" bodyMessage="Could not render plot due to all values being null." />
+                </foreignObject>
+              )}
             </g>
           ) : null}
         </svg>


### PR DESCRIPTION
Closes #99 

### Summary of changes
- raincloud vis fix: 
  - show error overlay for columns with null values only (covers special edge case found in bioinsight)

### Screenshots
![image](https://github.com/datavisyn/visyn_core/assets/101096478/a64869c7-37d9-47d8-abe3-1c42d985c780)