### PR TITLE
feat: add get_default_postgres_url utility

### DIFF
--- a/visyn_core/settings/model.py
+++ b/visyn_core/settings/model.py
@@ -205,6 +205,10 @@ class VisynCoreSettings(BaseModel):
 
 class GlobalSettings(BaseSettings):
     env: Literal["development", "production"] = "production"
+    ci: bool = False
+    """
+    Set to true in CI environments like Github Actions.
+    """
     secret_key: str = "VERY_SECRET_STUFF_T0IB84wlQrdMH8RVT28w"
 
     # JWT options mostly inspired by flask-jwt-extended: https://flask-jwt-extended.readthedocs.io/en/stable/options/#general-options

--- a/visyn_core/settings/utils.py
+++ b/visyn_core/settings/utils.py
@@ -34,11 +34,12 @@ def get_default_postgres_url(
     *,
     user: str = "admin",
     password: str = "admin",
-    host: str = os.getenv("POSTGRES_HOSTNAME", "localhost"),
+    host: str | None = os.getenv("POSTGRES_HOSTNAME"),
+    host_fallback: str = "localhost",
     port: int = 5432,
     database: str = "db",
 ) -> str:
     """
     Returns a default postgres url, including the default values for `user`, `password`, `host`, `port` and `database`.
     """
-    return f"postgresql://{user}:{password}@{host}:{port}/{database}"
+    return f"postgresql://{user}:{password}@{host or host_fallback}:{port}/{database}"

--- a/visyn_core/settings/utils.py
+++ b/visyn_core/settings/utils.py
@@ -28,3 +28,17 @@ def load_config_file(path: str) -> dict[str, Any]:
     """
     with codecs.open(path, "r", "utf-8") as fi:
         return jsoncfg.loads(fi.read()) or {}
+
+
+def get_default_postgres_url(
+    *,
+    user: str = "admin",
+    password: str = "admin",
+    host: str = os.getenv("POSTGRES_HOSTNAME", "localhost"),
+    port: int = 5432,
+    database: str = "db",
+) -> str:
+    """
+    Returns a default postgres url, including the default values for `user`, `password`, `host`, `port` and `database`.
+    """
+    return f"postgresql://{user}:{password}@{host}:{port}/{database}"


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [ ] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Adds a `get_default_postgres_url` utility to be used when defining default urls for postgres. The hostname for postgres may differ locally from the one in CI, such that this utility uses a default from an env variable, and falls back to localhost if it is not set. All our CI is configured to set this variable to the correct postgres host. 

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
