### PR TITLE
fix: violin plot bug

### DIFF
--- a/src/vis/stories/fetchIrisData.tsx
+++ b/src/vis/stories/fetchIrisData.tsx
@@ -10,7 +10,8 @@ export function fetchIrisData(): VisColumn[] {
         name: 'Sepal Length',
       },
       type: EColumnTypes.NUMERICAL,
-      values: () => dataPromise.map((r) => r.sepalLength).map((val, i) => ({ id: i.toString(), val })),
+      // values: () => dataPromise.map((r) => r.sepalLength).map((val, i) => ({ id: i.toString(), val })),
+      values: () => dataPromise.map((r) => r.sepalLength).map((val, i) => ({ id: i.toString(), val: i < 10 ? val : null })),
     },
     {
       info: {

--- a/src/vis/violin/ViolinVis.tsx
+++ b/src/vis/violin/ViolinVis.tsx
@@ -19,6 +19,16 @@ export function ViolinVis({ config, columns, scales, dimensions, selectedList, s
 
   const [layout, setLayout] = useState<Partial<Plotly.Layout>>(null);
 
+  const filteredTraces = useMemo(() => {
+    if (!traces) return null;
+    const filtered = {
+      ...traces,
+      plots: traces?.plots.filter((p) => (p.data.x as unknown[]).filter(Boolean).length === (p.data.y as unknown[]).filter(Boolean).length),
+    };
+    filtered.rows = Math.ceil(filtered.plots.length);
+    return filtered;
+  }, [traces]);
+
   const onClick = (e: Readonly<PlotlyTypes.PlotSelectionEvent> | null) => {
     if (!e || !e.points || !e.points[0]) {
       selectionCallback([]);
@@ -78,7 +88,7 @@ export function ViolinVis({ config, columns, scales, dimensions, selectedList, s
   }, [clearTimeoutValue]);
 
   useEffect(() => {
-    if (!traces) {
+    if (!filteredTraces) {
       return;
     }
 
@@ -99,12 +109,12 @@ export function ViolinVis({ config, columns, scales, dimensions, selectedList, s
       },
       clickmode: 'event+select',
       autosize: true,
-      grid: { rows: traces.rows, columns: traces.cols, xgap: 0.3, pattern: 'independent' },
+      grid: { rows: filteredTraces.rows, columns: filteredTraces.cols, xgap: 0.3, pattern: 'independent' },
       shapes: [],
     };
 
-    setLayout((prev) => ({ ...prev, ...beautifyLayout(traces, innerLayout, prev, true) }));
-  }, [traces]);
+    setLayout((prev) => ({ ...prev, ...beautifyLayout(filteredTraces, innerLayout, prev, true) }));
+  }, [filteredTraces]);
 
   return (
     <Stack
@@ -120,10 +130,10 @@ export function ViolinVis({ config, columns, scales, dimensions, selectedList, s
         },
       }}
     >
-      {traceStatus === 'success' && layout && traces?.plots.length > 0 ? (
+      {traceStatus === 'success' && layout && filteredTraces?.plots.length > 0 ? (
         <PlotlyComponent
           divId={`plotlyDiv${id}`}
-          data={[...traces.plots.map((p) => p.data), ...traces.legendPlots.map((p) => p.data)]}
+          data={[...filteredTraces.plots.map((p) => p.data), ...filteredTraces.legendPlots.map((p) => p.data)]}
           layout={layout}
           config={{ responsive: true, displayModeBar: false }}
           useResizeHandler
@@ -139,7 +149,7 @@ export function ViolinVis({ config, columns, scales, dimensions, selectedList, s
           }}
         />
       ) : traceStatus !== 'pending' && traceStatus !== 'idle' && layout ? (
-        <InvalidCols headerMessage={traces?.errorMessageHeader} bodyMessage={traceError?.message || traces?.errorMessage} />
+        <InvalidCols headerMessage={filteredTraces?.errorMessageHeader} bodyMessage={traceError?.message || filteredTraces?.errorMessage} />
       ) : null}
     </Stack>
   );


### PR DESCRIPTION
Closes #135 

### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [x] Requires UI/UX/Vis review
  - [x] Reviewer(s) are notified @dvdanielamoitzi 
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Checks if all the x and y values in the traces are non-nullish
- If not, it will not view the trace for the corresponding plot
- Calculates the `rows`based on the length of the plots in the traces


### Screenshots

> ### Important
> 
> - Please note that it does not view the plot for which there are null values since that would cause the application to break.
> - In the plot below, the number of plots fetched were 2 (one of them containing nullish values).
> - With this fix, the plot containing nullish values was filtered out.

![image](https://github.com/datavisyn/visyn_core/assets/115616380/8b074b4b-23d5-458b-8c77-e1c079b765f5)


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
