### PR TITLE
Fix: tooltip bug in violin plot

### DIFF
--- a/src/vis/stories/fetchIrisData.tsx
+++ b/src/vis/stories/fetchIrisData.tsx
@@ -10,7 +10,8 @@ export function fetchIrisData(): VisColumn[] {
         name: 'Sepal Length',
       },
       type: EColumnTypes.NUMERICAL,
-      values: () => dataPromise.map((r) => r.sepalLength).map((val, i) => ({ id: i.toString(), val })),
+      // values: () => dataPromise.map((r) => r.sepalLength).map((val, i) => ({ id: i.toString(), val })),
+      values: () => dataPromise.map((r) => r.sepalLength).map((val, i) => ({ id: i.toString(), val: i < 10 ? val : null })),
     },
     {
       info: {

--- a/src/vis/violin/ViolinVis.tsx
+++ b/src/vis/violin/ViolinVis.tsx
@@ -19,6 +19,16 @@ export function ViolinVis({ config, columns, scales, dimensions, selectedList, s
 
   const [layout, setLayout] = useState<Partial<Plotly.Layout>>(null);
 
+  const filteredTraces = useMemo(() => {
+    if (!traces) return null;
+    const filtered = {
+      ...traces,
+      plots: traces?.plots.filter((p) => (p.data.x as unknown[]).filter(Boolean).length === (p.data.y as unknown[]).filter(Boolean).length),
+    };
+    filtered.rows = Math.ceil(filtered.plots.length);
+    return filtered;
+  }, [traces]);
+
   const onClick = (e: Readonly<PlotlyTypes.PlotSelectionEvent> | null) => {
     if (!e || !e.points || !e.points[0]) {
       selectionCallback([]);
@@ -78,7 +88,7 @@ export function ViolinVis({ config, columns, scales, dimensions, selectedList, s
   }, [clearTimeoutValue]);
 
   useEffect(() => {
-    if (!traces) {
+    if (!filteredTraces) {
       return;
     }
 
@@ -99,12 +109,12 @@ export function ViolinVis({ config, columns, scales, dimensions, selectedList, s
       },
       clickmode: 'event+select',
       autosize: true,
-      grid: { rows: traces.rows, columns: traces.cols, xgap: 0.3, pattern: 'independent' },
+      grid: { rows: filteredTraces.rows, columns: filteredTraces.cols, xgap: 0.3, pattern: 'independent' },
       shapes: [],
     };
 
-    setLayout((prev) => ({ ...prev, ...beautifyLayout(traces, innerLayout, prev, true) }));
-  }, [traces]);
+    setLayout((prev) => ({ ...prev, ...beautifyLayout(filteredTraces, innerLayout, prev, true) }));
+  }, [filteredTraces]);
 
   return (
     <Stack
@@ -120,10 +130,10 @@ export function ViolinVis({ config, columns, scales, dimensions, selectedList, s
         },
       }}
     >
-      {traceStatus === 'success' && layout && traces?.plots.length > 0 ? (
+      {traceStatus === 'success' && layout && filteredTraces?.plots.length > 0 ? (
         <PlotlyComponent
           divId={`plotlyDiv${id}`}
-          data={[...traces.plots.map((p) => p.data), ...traces.legendPlots.map((p) => p.data)]}
+          data={[...filteredTraces.plots.map((p) => p.data), ...filteredTraces.legendPlots.map((p) => p.data)]}
           layout={layout}
           config={{ responsive: true, displayModeBar: false }}
           useResizeHandler
@@ -139,7 +149,7 @@ export function ViolinVis({ config, columns, scales, dimensions, selectedList, s
           }}
         />
       ) : traceStatus !== 'pending' && traceStatus !== 'idle' && layout ? (
-        <InvalidCols headerMessage={traces?.errorMessageHeader} bodyMessage={traceError?.message || traces?.errorMessage} />
+        <InvalidCols headerMessage={filteredTraces?.errorMessageHeader} bodyMessage={traceError?.message || filteredTraces?.errorMessage} />
       ) : null}
     </Stack>
   );

--- a/src/vis/violin/ViolinVis.tsx
+++ b/src/vis/violin/ViolinVis.tsx
@@ -22,7 +22,8 @@ export function ViolinVis({ config, columns, scales, dimensions, selectedList, s
   // Filter out null values from traces as null values cause the tooltip to not show up
   const filteredTraces = useMemo(() => {
     if (!traces) return null;
-    const indexWithNull = traces.plots?.map((plot) => (plot?.data.y as PlotlyTypes.Datum[])?.reduce((acc, curr, i) => (curr === null ? [...acc, i] : acc), []));
+    // @ts-ignore
+    const indexWithNull = traces.plots?.map((plot) => plot?.data.y?.reduce((acc, curr, i) => (curr === null ? [...acc, i] : acc), []));
     const filtered = {
       ...traces,
       plots: traces?.plots?.map((p, p_index) => {
@@ -30,10 +31,13 @@ export function ViolinVis({ config, columns, scales, dimensions, selectedList, s
           ...p,
           data: {
             ...p.data,
-            y: (p.data?.y as PlotlyTypes.Datum[])?.filter((v, i) => !indexWithNull[p_index].includes(i)),
-            x: (p.data?.x as PlotlyTypes.Datum[])?.filter((v, i) => !indexWithNull[p_index].includes(i)),
+            // @ts-ignore
+            y: p.data?.y?.filter((v, i) => !indexWithNull[p_index].includes(i)),
+            // @ts-ignore
+            x: p.data?.x?.filter((v, i) => !indexWithNull[p_index].includes(i)),
             ids: p.data?.ids?.filter((v, i) => !indexWithNull[p_index].includes(i)),
-            transforms: p.data?.transforms?.map((t) => (t.groups as number[] | string[])?.filter((v, i) => !indexWithNull[p_index].includes(i))),
+            // @ts-ignore
+            transforms: p.data?.transforms?.map((t) => t.groups?.filter((v, i) => !indexWithNull[p_index].includes(i))),
           },
         };
       }),

--- a/src/vis/violin/ViolinVis.tsx
+++ b/src/vis/violin/ViolinVis.tsx
@@ -19,13 +19,25 @@ export function ViolinVis({ config, columns, scales, dimensions, selectedList, s
 
   const [layout, setLayout] = useState<Partial<Plotly.Layout>>(null);
 
+  // Filter out null values from traces as null values cause the tooltip to not show up
   const filteredTraces = useMemo(() => {
     if (!traces) return null;
+    const indexWithNull = traces.plots?.map((plot) => plot?.data.y?.reduce((acc, curr, i) => (curr === null ? [...acc, i] : acc), []));
     const filtered = {
       ...traces,
-      plots: traces?.plots.filter((p) => (p.data.x as unknown[]).filter(Boolean).length === (p.data.y as unknown[]).filter(Boolean).length),
+      plots: traces?.plots?.map((p, p_index) => {
+        return {
+          ...p,
+          data: {
+            ...p.data,
+            y: p.data?.y?.filter((v, i) => !indexWithNull[p_index].includes(i)),
+            x: p.data?.x?.filter((v, i) => !indexWithNull[p_index].includes(i)),
+            ids: p.data?.ids?.filter((v, i) => !indexWithNull[p_index].includes(i)),
+            transforms: p.data?.transforms?.map((t) => t.groups?.filter((v, i) => !indexWithNull[p_index].includes(i))),
+          },
+        };
+      }),
     };
-    filtered.rows = Math.ceil(filtered.plots.length);
     return filtered;
   }, [traces]);
 

--- a/src/vis/violin/ViolinVis.tsx
+++ b/src/vis/violin/ViolinVis.tsx
@@ -22,7 +22,7 @@ export function ViolinVis({ config, columns, scales, dimensions, selectedList, s
   // Filter out null values from traces as null values cause the tooltip to not show up
   const filteredTraces = useMemo(() => {
     if (!traces) return null;
-    const indexWithNull = traces.plots?.map((plot) => plot?.data.y?.reduce((acc, curr, i) => (curr === null ? [...acc, i] : acc), []));
+    const indexWithNull = traces.plots?.map((plot) => (plot?.data.y as PlotlyTypes.Datum[])?.reduce((acc, curr, i) => (curr === null ? [...acc, i] : acc), []));
     const filtered = {
       ...traces,
       plots: traces?.plots?.map((p, p_index) => {
@@ -30,10 +30,10 @@ export function ViolinVis({ config, columns, scales, dimensions, selectedList, s
           ...p,
           data: {
             ...p.data,
-            y: p.data?.y?.filter((v, i) => !indexWithNull[p_index].includes(i)),
-            x: p.data?.x?.filter((v, i) => !indexWithNull[p_index].includes(i)),
+            y: (p.data?.y as PlotlyTypes.Datum[])?.filter((v, i) => !indexWithNull[p_index].includes(i)),
+            x: (p.data?.x as PlotlyTypes.Datum[])?.filter((v, i) => !indexWithNull[p_index].includes(i)),
             ids: p.data?.ids?.filter((v, i) => !indexWithNull[p_index].includes(i)),
-            transforms: p.data?.transforms?.map((t) => t.groups?.filter((v, i) => !indexWithNull[p_index].includes(i))),
+            transforms: p.data?.transforms?.map((t) => (t.groups as number[] | string[])?.filter((v, i) => !indexWithNull[p_index].includes(i))),
           },
         };
       }),


### PR DESCRIPTION
Closes #135 

### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [ ] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Removing all null values of the plots in the traces (affected props: x, y, ids, transform). In the below screencast, the upper plot contains lots of null values, and as you can see the tooltips are showing up again.

### Screenshots
[Screencast from 2024-01-09 19:21:23.webm](https://github.com/datavisyn/visyn_core/assets/57343176/25bb31bc-4a02-4725-8833-09072cc71ba4)


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
