### PR TITLE
fix: more specific `data-testid` in VisynApp header for Cypress tests

### DIFF
--- a/src/app/header/ConfigurationMenu.tsx
+++ b/src/app/header/ConfigurationMenu.tsx
@@ -27,7 +27,9 @@ export function ConfigurationMenu({ menu, dvLogo, aboutAppModal }: { menu: JSX.E
             </>
           ) : null}
           <Menu.Label>About</Menu.Label>
-          <Menu.Item onClick={() => setShowAboutModal(true)}>About {appName}</Menu.Item>
+          <Menu.Item data-testid="visyn-configuration-menu-about-app-button" onClick={() => setShowAboutModal(true)}>
+            About {appName}
+          </Menu.Item>
         </Menu.Dropdown>
       </Menu>
       <AboutAppModal

--- a/src/app/header/UserMenu.tsx
+++ b/src/app/header/UserMenu.tsx
@@ -31,7 +31,7 @@ export function UserMenu({ menu, user, color }: { menu: JSX.Element; user: strin
 
       <Menu.Dropdown>
         <>
-          <Menu.Label>Logged in as {user}</Menu.Label>
+          <Menu.Label data-testid="visyn-user-login-information">Logged in as {user}</Menu.Label>
           {menu ? (
             <>
               {menu}
@@ -39,7 +39,7 @@ export function UserMenu({ menu, user, color }: { menu: JSX.Element; user: strin
             </>
           ) : null}
           <Menu.Item
-            data-testid="user-menu-item"
+            data-testid="visyn-user-logout"
             onClick={() => {
               LoginUtils.logout();
             }}


### PR DESCRIPTION
Fixes failing cypress tests after https://github.com/datavisyn/reprovisyn/pull/1555

### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [x] Requires UI/UX/Vis review
  - [x] Reviewer(s) are notified @thinkh 
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes
- Added missing `data-testid` attributes

### Screenshots
- N/A

### Additional notes for the reviewer(s)
- N/A