### PR TITLE
extend mantine color types to add autocomplete

### DIFF
--- a/src/@types/mantine-overrides.d.ts
+++ b/src/@types/mantine-overrides.d.ts
@@ -1,0 +1,9 @@
+import { DefaultMantineColor, MantineColorsTuple } from '@mantine/core';
+
+type ExtendedCustomColors = 'dvPrimary' | 'dvGray' | 'dvGene' | 'dvDisease' | 'dvCellLine' | 'dvTissue' | 'dvDrug' | 'white' | DefaultMantineColor;
+
+declare module '@mantine/core' {
+  export interface MantineThemeColorsOverride {
+    colors: Record<ExtendedCustomColors, MantineColorsTuple>;
+  }
+}

--- a/src/app/VisynAppProvider.tsx
+++ b/src/app/VisynAppProvider.tsx
@@ -1,4 +1,4 @@
-import { MantineProvider, MantineProviderProps } from '@mantine/core';
+import { MantineProvider, MantineProviderProps, MantineColorsTuple, DefaultMantineColor, useMantineTheme } from '@mantine/core';
 import { ModalsProvider, ModalsProviderProps } from '@mantine/modals';
 import { Notifications, NotificationsProps } from '@mantine/notifications';
 import merge from 'lodash/merge';

--- a/src/app/constants.tsx
+++ b/src/app/constants.tsx
@@ -1,5 +1,5 @@
 import type { MantineProviderProps as Mantine6ProviderProps } from '@mantine6/core';
-import type { MantineProviderProps } from '@mantine/core';
+import type { MantineProviderProps, DefaultMantineColor, MantineColorsTuple } from '@mantine/core';
 
 export const DEFAULT_MANTINE6_PROVIDER_PROPS: Omit<Mantine6ProviderProps, 'children'> = {
   withNormalizeCSS: true,


### PR DESCRIPTION
Extend the mantine theme color type by the datavisyn colors