### PR TITLE
test: use app shell instead of body in cypress test

### DIFF
--- a/cypress/e2e/health-check.cy.ts
+++ b/cypress/e2e/health-check.cy.ts
@@ -7,13 +7,13 @@ describe('Health check for Cypress e2e test', () => {
     cy.get('input[name="password"]').type('admin');
     cy.get('button[type="submit"]').click();
     // Assert the content is now visible
-    cy.get('body').should('include.text', 'Visualization type');
+    cy.get('.mantine-AppShell-root').should('include.text', 'Visualization type');
     // Check the user avatar, and then log out again
     cy.get('[data-testid="visyn-user-avatar"]').should('include.text', 'A').click();
     cy.get('[data-testid="visyn-user-logout"]').contains('Logout').click();
     // Assert the login modal to be shown again
     cy.get('[data-testid="visyn-login-modal"]').should('include.text', 'Demo App');
     // Assert the content to be invisible again
-    cy.get('body').should('not.include.text', 'Visualization type');
+    cy.get('.mantine-AppShell-root').should('not.include.text', 'Visualization type');
   });
 });


### PR DESCRIPTION
I'm changing the cypress test to check the app shell to include the text instead of the whole body, as the body get's quite long with the styles. I think this is why it failed [here](https://github.com/datavisyn/visyn_core/actions/runs/8660082947/job/23752989727)

The build withe the cypress tests is successful for this branch: https://github.com/datavisyn/visyn_core/actions/runs/8662349056


-  
Thanks for creating this pull request 🤗
