### PR TITLE
feat: add possibility to insert score column after given column in ranking

### DIFF
--- a/src/ranking/overrides/DatavisynTaggle.tsx
+++ b/src/ranking/overrides/DatavisynTaggle.tsx
@@ -1,4 +1,4 @@
-import { IRankingDump, Ranking, Taggle, DataProvider, LocalDataProvider, TaggleRenderer } from 'lineupjs';
+import { Column, DataProvider, IRankingDump, LocalDataProvider, Ranking, Taggle, TaggleRenderer } from 'lineupjs';
 import castArray from 'lodash/castArray';
 import { IScoreColumnDesc, IScoreResult } from '../score/interfaces';
 
@@ -37,8 +37,9 @@ export class DatavisynTaggle<T extends DataProvider = LocalDataProvider> extends
    * Creates a score column in the supplied ranking. Uses the default ranking if none is supplied.
    *
    * @param desc The score description
+   * @param insertAfter The column to insert the score column after
    */
-  createScoreColumn(desc: IScoreResult, ranking = this.ranking) {
+  createScoreColumn(desc: IScoreResult, insertAfter?: Column, ranking = this.ranking) {
     if (!ranking) {
       throw new Error('No ranking found');
     }
@@ -55,6 +56,9 @@ export class DatavisynTaggle<T extends DataProvider = LocalDataProvider> extends
 
       const col = this.data.create(colDesc);
 
+      if (insertAfter) {
+        return ranking.insertAfter(col, insertAfter);
+      }
       return ranking.push(col);
     });
   }

--- a/src/ranking/overrides/DatavisynTaggle.tsx
+++ b/src/ranking/overrides/DatavisynTaggle.tsx
@@ -37,10 +37,10 @@ export class DatavisynTaggle<T extends DataProvider = LocalDataProvider> extends
    * Creates a score column in the supplied ranking. Uses the default ranking if none is supplied.
    *
    * @param desc The score description
-   * @param options Options for the score creation
+   * @param options Options for the score creation (optional)
    */
   createScoreColumn(desc: IScoreResult, options?: { ranking?: Ranking; insertAfter?: Column }) {
-    const ranking = options.ranking || this.ranking;
+    const ranking = options?.ranking || this.ranking;
 
     if (!ranking) {
       throw new Error('No ranking found');
@@ -58,7 +58,7 @@ export class DatavisynTaggle<T extends DataProvider = LocalDataProvider> extends
 
       const col = this.data.create(colDesc);
 
-      if (options.insertAfter) {
+      if (options?.insertAfter) {
         return ranking.insertAfter(col, options.insertAfter);
       }
       return ranking.push(col);

--- a/src/ranking/overrides/DatavisynTaggle.tsx
+++ b/src/ranking/overrides/DatavisynTaggle.tsx
@@ -37,9 +37,11 @@ export class DatavisynTaggle<T extends DataProvider = LocalDataProvider> extends
    * Creates a score column in the supplied ranking. Uses the default ranking if none is supplied.
    *
    * @param desc The score description
-   * @param insertAfter The column to insert the score column after
+   * @param options Options for the score creation
    */
-  createScoreColumn(desc: IScoreResult, insertAfter?: Column, ranking = this.ranking) {
+  createScoreColumn(desc: IScoreResult, options: { ranking?: Ranking; insertAfter?: Column }) {
+    const ranking = options.ranking || this.ranking;
+
     if (!ranking) {
       throw new Error('No ranking found');
     }
@@ -56,8 +58,8 @@ export class DatavisynTaggle<T extends DataProvider = LocalDataProvider> extends
 
       const col = this.data.create(colDesc);
 
-      if (insertAfter) {
-        return ranking.insertAfter(col, insertAfter);
+      if (options.insertAfter) {
+        return ranking.insertAfter(col, options.insertAfter);
       }
       return ranking.push(col);
     });

--- a/src/ranking/overrides/DatavisynTaggle.tsx
+++ b/src/ranking/overrides/DatavisynTaggle.tsx
@@ -39,7 +39,7 @@ export class DatavisynTaggle<T extends DataProvider = LocalDataProvider> extends
    * @param desc The score description
    * @param options Options for the score creation
    */
-  createScoreColumn(desc: IScoreResult, options: { ranking?: Ranking; insertAfter?: Column }) {
+  createScoreColumn(desc: IScoreResult, options?: { ranking?: Ranking; insertAfter?: Column }) {
     const ranking = options.ranking || this.ranking;
 
     if (!ranking) {


### PR DESCRIPTION
### Summary of changes
- added optional `insertAfter` parameter to `createScoreColumn` in order to better allow positioning of newly added score columns

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
