### PR TITLE
refactor: rename labels of filter buttons

### DIFF
--- a/src/vis/sidebar/FilterButtons.tsx
+++ b/src/vis/sidebar/FilterButtons.tsx
@@ -8,21 +8,21 @@ interface FilterButtonsProps {
 
 export function FilterButtons({ callback }: FilterButtonsProps) {
   return (
-    <Input.Wrapper label="Filter">
+    <Input.Wrapper label="Selected points">
       <Button.Group>
-        <Tooltip label="Filters any point not currently selected">
+        <Tooltip label="Remove all points that are currently not selected">
           <Button style={{ flexGrow: 1 }} p={0} variant="default" onClick={() => callback(EFilterOptions.IN)}>
-            {EFilterOptions.IN}
+            Remove
           </Button>
         </Tooltip>
-        <Tooltip label="Filters all currently selected points">
+        <Tooltip label="Keep all currently selected points">
           <Button style={{ flexGrow: 1 }} p={0} variant="default" onClick={() => callback(EFilterOptions.OUT)}>
-            {EFilterOptions.OUT}
+            Keep
           </Button>
         </Tooltip>
-        <Tooltip label="Removes any existing filter">
+        <Tooltip label="Remove existing point filter">
           <Button style={{ flexGrow: 1 }} p={0} variant="default" onClick={() => callback(EFilterOptions.CLEAR)}>
-            {EFilterOptions.CLEAR}
+            Clear
           </Button>
         </Tooltip>
       </Button.Group>


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [x] Requires UI/UX/Vis review
  - [x] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [ ] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Rename the filter labels to make it easier to use
- The option values remain the same

### Screenshots

**Before**

![grafik](https://github.com/datavisyn/visyn_core/assets/5851088/c8bd7a63-91d2-4b63-adab-3dd346233807)


**After**

![grafik](https://github.com/datavisyn/visyn_core/assets/5851088/263e386f-3280-498b-9aa5-97f1bb9eb9b3)


**Tooltips**

* **Keep**: Keep selected points, remove other points
* **Remove**: Remove selected points, keep other points
* **Clear**: Clear all point filters

### Additional notes for the reviewer(s)

The filter buttons are disabled in the visyn_core demo app by default. I enabled this for the screenshots above.

---  
Thanks for creating this pull request 🤗
