### PR TITLE
fix(vis): XY Labels in scatter vis hovertext

### DIFF
--- a/src/vis/scatter/Regression.tsx
+++ b/src/vis/scatter/Regression.tsx
@@ -340,10 +340,12 @@ export const fitRegressionLine = (
   const y = data.y as number[];
   const pearsonRho = round(corrcoeff(x, y), options.precision);
   const spearmanRho = round(spearmancoeff(x, y), options.precision);
-  const regressionResult = methods[regressionMethodsMapping[method]](
-    x.map((val, i) => [val, y[i]]),
-    options,
-  );
+  const regressionResult = regressionMethodsMapping[method]
+    ? methods[regressionMethodsMapping[method]](
+        x.map((val, i) => [val, y[i]]),
+        options,
+      )
+    : null;
   return {
     ...regressionResult,
     stats: { ...regressionResult.stats, pearsonRho, spearmanRho },

--- a/src/vis/scatter/ScatterVis.tsx
+++ b/src/vis/scatter/ScatterVis.tsx
@@ -130,7 +130,7 @@ export function ScatterVis({
   const regression: { shapes: Partial<Plotly.Shape>[]; results: IRegressionResult[] } = useMemo(() => {
     if (traces?.plots) {
       statsCallback(null);
-      if (config.regressionLineOptions.type !== ERegressionLineType.NONE) {
+      if (config.regressionLineOptions?.type && config.regressionLineOptions.type !== ERegressionLineType.NONE) {
         const regressionShapes: Partial<Plotly.Shape>[] = [];
         const regressionResults: IRegressionResult[] = [];
         for (const plot of traces.plots) {
@@ -183,7 +183,7 @@ export function ScatterVis({
         );
       }
 
-      if (config.regressionLineOptions.showStats) {
+      if (config.regressionLineOptions?.showStats) {
         combinedAnnotations.push(...annotationsForRegressionStats(regression.results, config.regressionLineOptions.fitOptions?.precision || 3));
       }
     }
@@ -307,7 +307,7 @@ export function ScatterVis({
           onHover={(event) => {
             // If we have subplots we set the stats for the current subplot on hover
             // It is up to the application to decide how to display the stats
-            if (config.regressionLineOptions.type !== ERegressionLineType.NONE && regression.results.length > 1) {
+            if (config.regressionLineOptions?.type && config.regressionLineOptions.type !== ERegressionLineType.NONE && regression.results.length > 1) {
               let result: IRegressionResult = null;
               if (regression.results.length > 0) {
                 const xAxis = event.points[0].yaxis.anchor;
@@ -319,7 +319,7 @@ export function ScatterVis({
           }}
           onUnhover={() => {
             // If we have subplots we clear the current stats when the mouse leaves the plot
-            if (config.regressionLineOptions.type !== ERegressionLineType.NONE && regression.results.length > 1) {
+            if (config.regressionLineOptions?.type && config.regressionLineOptions.type !== ERegressionLineType.NONE && regression.results.length > 1) {
               statsCallback(null);
             }
           }}

--- a/src/vis/scatter/utils.ts
+++ b/src/vis/scatter/utils.ts
@@ -392,11 +392,8 @@ export async function createScatterTraces(
   if (colorCol && colorCol.type === EColumnTypes.CATEGORICAL && validCols.length > 0) {
     legendPlots.push({
       data: {
-        x: validCols[0].resolvedValues.map((v) => v.val),
-        y: validCols[0].resolvedValues.map((v) => v.val),
-        ids: validCols[0].resolvedValues.map((v) => v.id?.toString()),
-        xaxis: 'x',
-        yaxis: 'y',
+        x: [null],
+        y: [null],
         type: 'scattergl',
         mode: 'markers',
         visible: 'legendonly',
@@ -428,8 +425,8 @@ export async function createScatterTraces(
           },
         ],
       },
-      xLabel: columnNameWithDescription(validCols[0].info),
-      yLabel: columnNameWithDescription(validCols[0].info),
+      xLabel: null,
+      yLabel: null,
     });
   }
 
@@ -437,11 +434,8 @@ export async function createScatterTraces(
   if (shapeCol) {
     legendPlots.push({
       data: {
-        x: validCols[0].resolvedValues.map((v) => v.val),
-        y: validCols[0].resolvedValues.map((v) => v.val),
-        ids: validCols[0].resolvedValues.map((v) => v.id?.toString()),
-        xaxis: 'x',
-        yaxis: 'y',
+        x: [null],
+        y: [null],
         type: 'scattergl',
         mode: 'markers',
         visible: 'legendonly',
@@ -474,8 +468,8 @@ export async function createScatterTraces(
           },
         ],
       },
-      xLabel: columnNameWithDescription(validCols[0].info),
-      yLabel: columnNameWithDescription(validCols[0].info),
+      xLabel: null,
+      yLabel: null,
     });
   }
 

--- a/src/vis/scatter/utils.ts
+++ b/src/vis/scatter/utils.ts
@@ -204,6 +204,9 @@ export async function createScatterTraces(
 
   // Case: Facetting by category
   if (validCols.length === 2 && facetCol) {
+    const xLabel = columnNameWithDescription(validCols[0].info);
+    const yLabel = columnNameWithDescription(validCols[1].info);
+
     const data = validCols[0].resolvedValues.map((v, i) => ({
       x: v.val,
       y: validCols[1].resolvedValues[i].val,
@@ -215,7 +218,7 @@ export async function createScatterTraces(
 
     const groupedData = _.groupBy(data, 'facet');
 
-    _.flatMap(groupedData, (group) => {
+    _.flatMap(groupedData, (group, key) => {
       const calcXDomain = calculateDomain(
         (validCols[0] as VisNumericalColumn).domain,
         group.map((d) => d.x as number),
@@ -234,8 +237,9 @@ export async function createScatterTraces(
           yaxis: plotCounter === 1 ? 'y' : `y${plotCounter}`,
           hovertext: group.map(
             (d) =>
-              `${idToLabelMapper(d.ids)}<br>x: ${d.x}<br>y: ${d.y}
-              ${shapeCol ? `<br>${columnNameWithDescription(shapeCol.info)}: ${d.shape}` : ''}`,
+              `${idToLabelMapper(d.ids)}<br>${xLabel}: ${d.x}<br>${yLabel}: ${d.y}
+              ${colorCol ? `<br>${columnNameWithDescription(colorCol.info)}: ${d.color}` : ''}
+              ${shapeCol && shapeCol.info.id !== colorCol?.info.id ? `<br>${columnNameWithDescription(shapeCol.info)}: ${d.shape}` : ''}`,
           ),
           text: group.map((d) => idToLabelMapper(d.ids)),
           // @ts-ignore
@@ -254,8 +258,8 @@ export async function createScatterTraces(
           },
           ...sharedData,
         },
-        xLabel: columnNameWithDescription(validCols[0].info),
-        yLabel: columnNameWithDescription(validCols[1].info),
+        xLabel,
+        yLabel,
         xDomain: calcXDomain,
         yDomain: calcYDomain,
         title: !group[0].facet || group[0].facet === '' ? 'Unknown' : group[0].facet,
@@ -268,6 +272,8 @@ export async function createScatterTraces(
   if (validCols.length === 2 && !facetCol) {
     const xDataVals = validCols[0].resolvedValues.map((v) => v.val) as number[];
     const yDataVals = validCols[1].resolvedValues.map((v) => v.val) as number[];
+    const xLabel = columnNameWithDescription(validCols[0].info);
+    const yLabel = columnNameWithDescription(validCols[1].info);
 
     const calcXDomain = calculateDomain((validCols[0] as VisNumericalColumn).domain, xDataVals);
     const calcYDomain = calculateDomain((validCols[1] as VisNumericalColumn).domain, yDataVals);
@@ -281,9 +287,9 @@ export async function createScatterTraces(
         yaxis: plotCounter === 1 ? 'y' : `y${plotCounter}`,
         hovertext: validCols[0].resolvedValues.map(
           (v, i) =>
-            `${idToLabelMapper(v.id)}<br>x: ${v.val}<br>y: ${validCols[1].resolvedValues[i].val}${
-              colorCol ? `<br>${columnNameWithDescription(colorCol.info)}: ${colorCol.resolvedValues[i].val}` : ''
-            }${shapeCol ? `<br>${columnNameWithDescription(shapeCol.info)}: ${shapeCol.resolvedValues[i].val}` : ''}`,
+            `${idToLabelMapper(v.id)}<br>${xLabel}: ${v.val}<br>${yLabel}: ${yDataVals[i]}
+            ${colorCol ? `<br>${columnNameWithDescription(colorCol.info)}: ${colorCol.resolvedValues[i].val}` : ''}
+            ${shapeCol && shapeCol.info.id !== colorCol?.info.id ? `<br>${columnNameWithDescription(shapeCol.info)}: ${shapeCol.resolvedValues[i].val}` : ''}`,
         ),
         text: validCols[0].resolvedValues.map((v) => idToLabelMapper(v.id)),
         // @ts-ignore
@@ -299,8 +305,8 @@ export async function createScatterTraces(
         },
         ...sharedData,
       },
-      xLabel: columnNameWithDescription(validCols[0].info),
-      yLabel: columnNameWithDescription(validCols[1].info),
+      xLabel,
+      yLabel,
       xDomain: calcXDomain,
       yDomain: calcYDomain,
     });
@@ -333,8 +339,10 @@ export async function createScatterTraces(
           // otherwise, make a scatterplot
         } else {
           const xDataVals = xCurr.resolvedValues.map((v) => v.val);
-
           const yDataVals = yCurr.resolvedValues.map((v) => v.val);
+
+          const xLabel = columnNameWithDescription(xCurr.info);
+          const yLabel = columnNameWithDescription(yCurr.info);
 
           const calcXDomain = calculateDomain((xCurr as VisNumericalColumn).domain, xDataVals as number[]);
           const calcYDomain = calculateDomain((yCurr as VisNumericalColumn).domain, yDataVals as number[]);
@@ -348,9 +356,9 @@ export async function createScatterTraces(
               yaxis: plotCounter === 1 ? 'y' : `y${plotCounter}`,
               hovertext: xCurr.resolvedValues.map(
                 (v, i) =>
-                  `${v.id}<br>x: ${v.val}<br>y: ${yCurr.resolvedValues[i].val}<br>${
-                    colorCol ? `${columnNameWithDescription(colorCol.info)}: ${colorCol.resolvedValues[i].val}` : ''
-                  }`,
+                  `${v.id}<br>${xLabel}: ${v.val}<br>${yLabel}: ${yCurr.resolvedValues[i].val}
+                ${colorCol ? `<br>${columnNameWithDescription(colorCol.info)}: ${colorCol.resolvedValues[i].val}` : ''}
+                ${shapeCol && shapeCol.info.id !== colorCol?.info.id ? `<br>${columnNameWithDescription(shapeCol.info)}: ${shapeCol.resolvedValues[i].val}` : ''}`,
               ),
               text: validCols[0].resolvedValues.map((v) => v.id?.toString()),
               // @ts-ignore
@@ -368,8 +376,8 @@ export async function createScatterTraces(
               },
               ...sharedData,
             },
-            xLabel: plotCounter > validCols.length * (validCols.length - 1) ? columnNameWithDescription(xCurr.info) : null,
-            yLabel: plotCounter === 1 + validCols.length * yIdx ? columnNameWithDescription(yCurr.info) : null,
+            xLabel: plotCounter > validCols.length * (validCols.length - 1) ? xLabel : null,
+            yLabel: plotCounter === 1 + validCols.length * yIdx ? yLabel : null,
             xDomain: calcXDomain,
             yDomain: calcYDomain,
           });

--- a/src/vis/scatter/utils.ts
+++ b/src/vis/scatter/utils.ts
@@ -238,8 +238,8 @@ export async function createScatterTraces(
           hovertext: group.map(
             (d) =>
               `${idToLabelMapper(d.ids)}<br>${xLabel}: ${d.x}<br>${yLabel}: ${d.y}
-              ${colorCol ? `<br>${columnNameWithDescription(colorCol.info)}: ${d.color}` : ''}
-              ${shapeCol && shapeCol.info.id !== colorCol?.info.id ? `<br>${columnNameWithDescription(shapeCol.info)}: ${d.shape}` : ''}`,
+              ${colorCol ? `<br>${columnNameWithDescription(colorCol.info)}: ${d.color || 'Unknown'}` : ''}
+              ${shapeCol && shapeCol.info.id !== colorCol?.info.id ? `<br>${columnNameWithDescription(shapeCol.info)}: ${d.shape || 'Unknown'}` : ''}`,
           ),
           text: group.map((d) => idToLabelMapper(d.ids)),
           // @ts-ignore
@@ -288,8 +288,8 @@ export async function createScatterTraces(
         hovertext: validCols[0].resolvedValues.map(
           (v, i) =>
             `${idToLabelMapper(v.id)}<br>${xLabel}: ${v.val}<br>${yLabel}: ${yDataVals[i]}
-            ${colorCol ? `<br>${columnNameWithDescription(colorCol.info)}: ${colorCol.resolvedValues[i].val}` : ''}
-            ${shapeCol && shapeCol.info.id !== colorCol?.info.id ? `<br>${columnNameWithDescription(shapeCol.info)}: ${shapeCol.resolvedValues[i].val}` : ''}`,
+            ${colorCol ? `<br>${columnNameWithDescription(colorCol.info)}: ${colorCol.resolvedValues[i].val || 'Unknown'}` : ''}
+            ${shapeCol && shapeCol.info.id !== colorCol?.info.id ? `<br>${columnNameWithDescription(shapeCol.info)}: ${shapeCol.resolvedValues[i].val || 'Unknown'}` : ''}`,
         ),
         text: validCols[0].resolvedValues.map((v) => idToLabelMapper(v.id)),
         // @ts-ignore
@@ -357,8 +357,8 @@ export async function createScatterTraces(
               hovertext: xCurr.resolvedValues.map(
                 (v, i) =>
                   `${v.id}<br>${xLabel}: ${v.val}<br>${yLabel}: ${yCurr.resolvedValues[i].val}
-                ${colorCol ? `<br>${columnNameWithDescription(colorCol.info)}: ${colorCol.resolvedValues[i].val}` : ''}
-                ${shapeCol && shapeCol.info.id !== colorCol?.info.id ? `<br>${columnNameWithDescription(shapeCol.info)}: ${shapeCol.resolvedValues[i].val}` : ''}`,
+                ${colorCol ? `<br>${columnNameWithDescription(colorCol.info)}: ${colorCol.resolvedValues[i].val || 'Unknown'}` : ''}
+                ${shapeCol && shapeCol.info.id !== colorCol?.info.id ? `<br>${columnNameWithDescription(shapeCol.info)}: ${shapeCol.resolvedValues[i].val || 'Unknown'}` : ''}`,
               ),
               text: validCols[0].resolvedValues.map((v) => v.id?.toString()),
               // @ts-ignore


### PR DESCRIPTION
Closes #303 

### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes
- Various scattervis improvements
  - show actual x/y axis labels in hovertext instead of only _x_ _y_  
  - fix occasional application crash on regression line change
  - improve scattervis trace calculation on color/shape column select

### Screenshots
![image](https://github.com/datavisyn/visyn_core/assets/101096478/8814e37b-77fc-4552-a2c0-8179ca36f610)


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
