### PR TITLE
fix(vis-heatmap): disable deselection of aggregation type

### DIFF
--- a/src/vis/sidebar/AggregateTypeSelect.tsx
+++ b/src/vis/sidebar/AggregateTypeSelect.tsx
@@ -37,6 +37,7 @@ export function AggregateTypeSelect({
     <>
       <Select
         label="Aggregate type"
+        allowDeselect={false}
         onChange={(option) => aggregateTypeSelectCallback(option as EAggregateTypes)}
         name="numColumns"
         data={selectOptions || []}


### PR DESCRIPTION
Closes https://github.com/datavisyn/visyn_core/issues/332

Closes *list issues numbers here*

### Developer Checklist (Definition of Done)

**Issue**

- [ ] All acceptance criteria from the issue are met
- [ ] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [ ] Branch is up-to-date with the branch to be merged with, i.e., develop
- [ ] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [ ] Descriptive title for this pull request is provided (will be used for release notes later)
- [ ] Reviewer and assignees are defined
- [ ] Add type label (e.g., *bug*, *feature*) to this pull request
- [ ] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [ ] The PR is connected to the corresponding issue (via `Closes #...`)
- [ ] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- The select is used in the Bar and heat map plots, in both cases same behavior applies. You should not be able to deselect it

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
