### PR TITLE
Feat: add property isShiftKeyPressed to sortIcon

### DIFF
--- a/src/vis/general/SortIcon.tsx
+++ b/src/vis/general/SortIcon.tsx
@@ -19,7 +19,7 @@ export function SortIcon({
   compact = false,
 }: {
   sortState: ESortStates;
-  setSortState: (sortState: ESortStates) => void;
+  setSortState: (sortState: ESortStates, isShiftKeyPressed: boolean) => void;
   priority?: number;
   compact?: boolean;
 }) {
@@ -36,7 +36,7 @@ export function SortIcon({
   };
 
   return (
-    <Group onClick={() => setSortState(getNextSortState(sortState))}>
+    <Group onClick={(e) => setSortState(getNextSortState(sortState), e.shiftKey)}>
       <Tooltip
         withArrow
         withinPortal


### PR DESCRIPTION
Closes *list issues numbers here*

### Summary of changes

- For the priority sort in Oncoprint, we need to check if the shift key was pressed during the click on the sort icon
- added isShiftKeyPressed property to the callback function in the SortIcon

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
