### PR TITLE
Fix: use ctrl for priority sort instead of shift

### DIFF
--- a/src/vis/general/SortIcon.tsx
+++ b/src/vis/general/SortIcon.tsx
@@ -19,7 +19,7 @@ export function SortIcon({
   compact = false,
 }: {
   sortState: ESortStates;
-  setSortState: (sortState: ESortStates, isCtrlKeyPressed: boolean) => void;
+  setSortState: (sortState: ESortStates, isCtrlKeyPressed: boolean, event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
   priority?: number;
   compact?: boolean;
 }) {
@@ -36,7 +36,7 @@ export function SortIcon({
   };
 
   return (
-    <Group onClick={(e) => setSortState(getNextSortState(sortState), e.ctrlKey)}>
+    <Group onClick={(e) => setSortState(getNextSortState(sortState), e.ctrlKey, e)}>
       <Tooltip
         withArrow
         withinPortal

--- a/src/vis/general/SortIcon.tsx
+++ b/src/vis/general/SortIcon.tsx
@@ -36,7 +36,7 @@ export function SortIcon({
   };
 
   return (
-    <Group onClick={(e) => setSortState(getNextSortState(sortState), e.shiftKey)}>
+    <Group onClick={(e) => setSortState(getNextSortState(sortState), e.ctrlKey)}>
       <Tooltip
         withArrow
         withinPortal

--- a/src/vis/general/SortIcon.tsx
+++ b/src/vis/general/SortIcon.tsx
@@ -19,7 +19,7 @@ export function SortIcon({
   compact = false,
 }: {
   sortState: ESortStates;
-  setSortState: (sortState: ESortStates, isShiftKeyPressed: boolean) => void;
+  setSortState: (sortState: ESortStates, isCtrlKeyPressed: boolean) => void;
   priority?: number;
   compact?: boolean;
 }) {


### PR DESCRIPTION
### Summary of changes

- Using CTRL instead of SHIFT for the event in the sort icon, to align it with lineup.

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
