### PR TITLE
fix: Setting Plotly version to ~2.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "jstat": "^1.9.6",
     "lineupjs": "4.11.0",
     "lodash": "~4.17.21",
-    "plotly.js-dist-min": "~2.33.0",
+    "plotly.js-dist-min": "~2.12.0",
     "react": "~18.3.1",
     "react-dom": "~18.3.1",
     "react-highlight-words": "^0.20.0",


### PR DESCRIPTION
Closes https://github.com/datavisyn/visyn_core/issues/366

With version 2.12.0 the lasso selection still works. From 2.13.0 upwards the lasso fails.