### PR TITLE
Release 11.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "visyn_core",
   "description": "Core repository for datavisyn applications.",
-  "version": "11.0.1",
+  "version": "11.0.2-SNAPSHOT",
   "author": {
     "name": "datavisyn GmbH",
     "email": "contact@datavisyn.io",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "jstat": "^1.9.6",
     "lineupjs": "4.11.0",
     "lodash": "~4.17.21",
-    "plotly.js-dist-min": "~2.33.0",
+    "plotly.js-dist-min": "~2.12.0",
     "react": "~18.3.1",
     "react-dom": "~18.3.1",
     "react-highlight-words": "^0.20.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "visyn_core",
   "description": "Core repository for datavisyn applications.",
-  "version": "11.0.2-SNAPSHOT",
+  "version": "11.1.0",
   "author": {
     "name": "datavisyn GmbH",
     "email": "contact@datavisyn.io",

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ pyjwt[crypto]==2.8.0
 pytest-postgresql==6.0.0
 python-dateutil==2.9.0.post0
 requests==2.32.3
+sentry-sdk~=2.6.0
 SQLAlchemy>=1.4.40,<=1.4.49
 starlette-context==0.3.6
 uvicorn[standard]==0.30.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ opentelemetry-instrumentation-system-metrics==0.46b0
 opentelemetry-sdk==1.25.0
 psycopg==3.1.19
 psycopg2==2.9.9
-pydantic==1.10.15
+pydantic==1.10.16
 pyjwt[crypto]==2.8.0
 pytest-postgresql==6.0.0
 python-dateutil==2.9.0.post0

--- a/src/vis/general/SortIcon.tsx
+++ b/src/vis/general/SortIcon.tsx
@@ -19,7 +19,7 @@ export function SortIcon({
   compact = false,
 }: {
   sortState: ESortStates;
-  setSortState: (sortState: ESortStates, isShiftKeyPressed: boolean) => void;
+  setSortState: (sortState: ESortStates, isCtrlKeyPressed: boolean, event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
   priority?: number;
   compact?: boolean;
 }) {
@@ -36,7 +36,7 @@ export function SortIcon({
   };
 
   return (
-    <Group onClick={(e) => setSortState(getNextSortState(sortState), e.shiftKey)}>
+    <Group onClick={(e) => setSortState(getNextSortState(sortState), e.ctrlKey, e)}>
       <Tooltip
         withArrow
         withinPortal

--- a/visyn_core/server/visyn_server.py
+++ b/visyn_core/server/visyn_server.py
@@ -97,6 +97,21 @@ def create_visyn_server(
 
         init_telemetry(app, settings=manager.settings.visyn_core.telemetry)
 
+    if manager.settings.visyn_core.sentry.dsn:
+        import sentry_sdk
+
+        sentry_sdk.init(
+            dsn=manager.settings.visyn_core.sentry.dsn,
+            # Set traces_sample_rate to 1.0 to capture 100%
+            # of transactions for tracing.
+            traces_sample_rate=1.0,
+            # Set profiles_sample_rate to 1.0 to profile 100%
+            # of sampled transactions.
+            # We recommend adjusting this value in production.
+            profiles_sample_rate=1.0,
+            **manager.settings.visyn_core.sentry.server_init_options,
+        )
+
     # Initialize global managers.
     from ..plugin.registry import Registry
 

--- a/visyn_core/settings/model.py
+++ b/visyn_core/settings/model.py
@@ -163,6 +163,10 @@ class SentrySettings(BaseModel):
     """
     Proxy Sentry envelopes to this URL. Used if an internal Sentry server is used, otherwise the original DSN is used.
     """
+    server_init_options: dict[str, Any] = {}
+    """
+    Options to be passed to the Sentry SDK during initialization.
+    """
 
 
 class VisynCoreSettings(BaseModel):


### PR DESCRIPTION
## What's changed

* fix: Setting Plotly version to ~2.12.0 (https://github.com/datavisyn/visyn_core/pull/367)
* Fix: use ctrl for priority sort instead of shift (https://github.com/datavisyn/visyn_core/pull/365)
* feat: add sentry FastAPI integration (https://github.com/datavisyn/visyn_core/pull/364)
* chore(deps): bump pydantic from 1.10.14 to 1.10.16 (https://github.com/datavisyn/visyn_core/pull/357)