### PR TITLE
Added setRef hook

### DIFF
--- a/src/hooks/Hooks.stories.tsx
+++ b/src/hooks/Hooks.stories.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { StoryObj, Meta } from '@storybook/react';
+import { Button, Center, Stack } from '@mantine/core';
+import { useSetRef } from './useSetRef';
+
+function SetRefTest() {
+  const [element, setElement] = React.useState<HTMLElement>();
+  const { setRef } = useSetRef({
+    register: (el) => {
+      setElement(el);
+    },
+    cleanup: (el) => {
+      setElement(undefined);
+    },
+  });
+  const [visible, setVisible] = React.useState(false);
+
+  const toggle = () => {
+    setVisible((v) => !v);
+  };
+
+  return (
+    <Center w={600} h={400}>
+      <Stack>
+        <Button onClick={toggle}>Toggle visibility</Button>
+
+        {visible ? <div ref={setRef}>Current element is {element?.nodeName}</div> : <div>No element</div>}
+      </Stack>
+    </Center>
+  );
+}
+
+const meta: Meta<typeof SetRefTest> = {
+  component: SetRefTest,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SetRefTest>;
+
+export const UseSetRef: Story = {};

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -3,3 +3,4 @@ export * from './useEvent';
 export * from './useInitVisynApp';
 export * from './useSyncedRef';
 export * from './useVisynUser';
+export * from './useSetRef';

--- a/src/hooks/useSetRef.ts
+++ b/src/hooks/useSetRef.ts
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { useSyncedRef } from './useSyncedRef';
+
+/**
+ * Hook that provides a setRef function, passable to the ref prop of a React element.
+ * The setRef function will register and cleanup the element with the provided callbacks.
+ */
+export function useSetRef(props?: { cleanup: (lastElement: HTMLElement) => void; register: (element: HTMLElement) => void }) {
+  const ref = React.useRef<HTMLElement>();
+
+  const callbackRef = useSyncedRef(props);
+
+  const setRef = React.useCallback(
+    (newElement: HTMLElement | null) => {
+      if (ref.current) {
+        callbackRef.current?.cleanup(ref.current);
+      }
+
+      if (newElement) {
+        callbackRef.current?.register(newElement);
+      }
+
+      ref.current = newElement;
+    },
+    [callbackRef],
+  );
+
+  return {
+    setRef,
+  };
+}


### PR DESCRIPTION
The problem:
Suppose we have an element which we track with useRef
```
const ref = React.useRef<HTMLElement>();
<div ref={ref} />
```
The ref will not trigger useEffects since the reference never changes, this can cause stale state as seen in pharmDB with the wheel listeners.

The solution:
use a ref callback, which will trigger everytime the component remounts. I encapsulated this logic into a reusable form

For reference, see:
https://legacy.reactjs.org/docs/hooks-faq.html?source=post_page-----eb7c15198780--------------------------------#how-can-i-measure-a-dom-node
https://medium.com/@teh_builder/ref-objects-inside-useeffect-hooks-eb7c15198780