### PR TITLE
feat(vis): focus facet selector for bar chart

### DIFF
--- a/src/vis/bar/BarChart.tsx
+++ b/src/vis/bar/BarChart.tsx
@@ -1,4 +1,4 @@
-import { Box, Loader, SimpleGrid, Stack, Center } from '@mantine/core';
+import { Box, Loader, SimpleGrid, Stack, Center, Select } from '@mantine/core';
 import { op } from 'arquero';
 import React, { useCallback, useMemo } from 'react';
 import { uniqueId } from 'lodash';
@@ -11,6 +11,8 @@ import { useGetGroupedBarScales } from './hooks/useGetGroupedBarScales';
 import { getBarData } from './utils';
 import { IBarConfig, SortTypes } from './interfaces';
 import { DownloadPlotButton } from '../general/DownloadPlotButton';
+import { getLabelOrUnknown } from '../general/utils';
+import { NAN_REPLACEMENT } from '../general';
 
 export function BarChart({
   config,
@@ -38,7 +40,7 @@ export function BarChart({
   ]);
 
   const allUniqueFacetVals = useMemo(() => {
-    return [...new Set(allColumns?.facetsColVals?.resolvedValues.map((v) => v.val))] as string[];
+    return [...new Set(allColumns?.facetsColVals?.resolvedValues.map((v) => v.val || getLabelOrUnknown(v.val)))] as string[];
   }, [allColumns?.facetsColVals?.resolvedValues]);
 
   const filteredUniqueFacetVals = useMemo(() => {
@@ -81,6 +83,16 @@ export function BarChart({
     <Stack pr="40px" flex={1} style={{ width: '100%', height: '100%' }}>
       {showDownloadScreenshot ? (
         <Center h="20px">
+          {config.facets && allUniqueFacetVals.length > 0 ? (
+            <Select
+              placeholder="Select a focus facet"
+              data={allUniqueFacetVals}
+              onChange={(value) => {
+                setConfig({ ...config, focusFacetIndex: typeof value === 'string' ? allUniqueFacetVals.indexOf(value) : value });
+              }}
+              clearable
+            />
+          ) : null}
           <DownloadPlotButton uniquePlotId={id} config={config} />
         </Center>
       ) : null}
@@ -136,7 +148,7 @@ export function BarChart({
                   config={config}
                   setConfig={setConfig}
                   allColumns={allColumns}
-                  categoryFilter={multiplesVal}
+                  categoryFilter={multiplesVal === NAN_REPLACEMENT ? null : multiplesVal}
                   title={multiplesVal}
                   selectionCallback={customSelectionCallback}
                   sortType={sortType}

--- a/src/vis/bar/BarChart.tsx
+++ b/src/vis/bar/BarChart.tsx
@@ -1,4 +1,4 @@
-import { Box, Center, Loader, Stack } from '@mantine/core';
+import { Box, Center, Group, Loader, Stack } from '@mantine/core';
 import { useResizeObserver } from '@mantine/hooks';
 import { uniqueId } from 'lodash';
 import React, { useCallback, useMemo } from 'react';
@@ -81,11 +81,11 @@ export function BarChart({
 
   return (
     <Stack pr="40px" flex={1} style={{ width: '100%', height: '100%' }}>
-      {showDownloadScreenshot ? (
-        <Center h="20px">
-          {config.facets && allUniqueFacetVals.length > 0 ? <FocusFacetSelector config={config} setConfig={setConfig} facets={allUniqueFacetVals} /> : null}
-          <DownloadPlotButton uniquePlotId={id} config={config} />
-        </Center>
+      {showDownloadScreenshot || config.showFocusFacetSelector ? (
+        <Group justify="center">
+          {config.showFocusFacetSelector ? <FocusFacetSelector config={config} setConfig={setConfig} facets={allUniqueFacetVals} /> : null}
+          {showDownloadScreenshot ? <DownloadPlotButton uniquePlotId={id} config={config} /> : null}
+        </Group>
       ) : null}
       <Stack gap={0} id={id} style={{ width: '100%', height: showDownloadScreenshot ? 'calc(100% - 20px)' : '100%' }}>
         <Box ref={legendBoxRef}>

--- a/src/vis/bar/BarChart.tsx
+++ b/src/vis/bar/BarChart.tsx
@@ -1,18 +1,19 @@
-import { Box, Loader, SimpleGrid, Stack, Center, Select } from '@mantine/core';
-import { op } from 'arquero';
-import React, { useCallback, useMemo } from 'react';
-import { uniqueId } from 'lodash';
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { ActionIcon, Box, Center, Group, Loader, Select, Stack, Tooltip } from '@mantine/core';
 import { useResizeObserver } from '@mantine/hooks';
+import { uniqueId } from 'lodash';
+import React, { useCallback, useMemo } from 'react';
 import { useAsync } from '../../hooks/useAsync';
+import { NAN_REPLACEMENT } from '../general';
+import { DownloadPlotButton } from '../general/DownloadPlotButton';
+import { getLabelOrUnknown } from '../general/utils';
 import { EColumnTypes, ICommonVisProps } from '../interfaces';
 import { SingleBarChart } from './SingleBarChart';
 import { Legend } from './barComponents/Legend';
 import { useGetGroupedBarScales } from './hooks/useGetGroupedBarScales';
-import { getBarData } from './utils';
 import { IBarConfig, SortTypes } from './interfaces';
-import { DownloadPlotButton } from '../general/DownloadPlotButton';
-import { getLabelOrUnknown } from '../general/utils';
-import { NAN_REPLACEMENT } from '../general';
+import { getBarData } from './utils';
 
 export function BarChart({
   config,
@@ -84,14 +85,42 @@ export function BarChart({
       {showDownloadScreenshot ? (
         <Center h="20px">
           {config.facets && allUniqueFacetVals.length > 0 ? (
-            <Select
-              placeholder="Select a focus facet"
-              data={allUniqueFacetVals}
-              onChange={(value) => {
-                setConfig({ ...config, focusFacetIndex: typeof value === 'string' ? allUniqueFacetVals.indexOf(value) : value });
-              }}
-              clearable
-            />
+            <Group gap={4}>
+              <Select
+                key={`focusFacetSelect_${config.focusFacetIndex}`}
+                placeholder="Select a focus facet"
+                data={allUniqueFacetVals}
+                value={allUniqueFacetVals[config.focusFacetIndex] || ''}
+                onChange={(value) => {
+                  setConfig({ ...config, focusFacetIndex: typeof value === 'string' ? allUniqueFacetVals.indexOf(value) : value });
+                }}
+                clearable
+              />
+              <Tooltip label="Focus on previous facet" position="top" withArrow>
+                <ActionIcon
+                  color="dvGray"
+                  variant="subtle"
+                  disabled={config.focusFacetIndex === null}
+                  onClick={() => {
+                    setConfig({ ...config, focusFacetIndex: (config.focusFacetIndex - 1 + allUniqueFacetVals.length) % allUniqueFacetVals.length });
+                  }}
+                >
+                  <FontAwesomeIcon icon={faChevronLeft} />
+                </ActionIcon>
+              </Tooltip>
+              <Tooltip label="Focus on next facet" position="top" withArrow>
+                <ActionIcon
+                  color="dvGray"
+                  variant="subtle"
+                  disabled={config.focusFacetIndex === null}
+                  onClick={() => {
+                    setConfig({ ...config, focusFacetIndex: (config.focusFacetIndex + 1) % allUniqueFacetVals.length });
+                  }}
+                >
+                  <FontAwesomeIcon icon={faChevronRight} />
+                </ActionIcon>
+              </Tooltip>
+            </Group>
           ) : null}
           <DownloadPlotButton uniquePlotId={id} config={config} />
         </Center>

--- a/src/vis/bar/BarChart.tsx
+++ b/src/vis/bar/BarChart.tsx
@@ -40,7 +40,7 @@ export function BarChart({
   ]);
 
   const allUniqueFacetVals = useMemo(() => {
-    return [...new Set(allColumns?.facetsColVals?.resolvedValues.map((v) => v.val || getLabelOrUnknown(v.val)))] as string[];
+    return [...new Set(allColumns?.facetsColVals?.resolvedValues.map((v) => getLabelOrUnknown(v.val)))] as string[];
   }, [allColumns?.facetsColVals?.resolvedValues]);
 
   const filteredUniqueFacetVals = useMemo(() => {

--- a/src/vis/bar/BarChart.tsx
+++ b/src/vis/bar/BarChart.tsx
@@ -1,6 +1,4 @@
-import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { ActionIcon, Box, Center, Group, Loader, Select, Stack, Tooltip } from '@mantine/core';
+import { Box, Center, Loader, Stack } from '@mantine/core';
 import { useResizeObserver } from '@mantine/hooks';
 import { uniqueId } from 'lodash';
 import React, { useCallback, useMemo } from 'react';
@@ -10,6 +8,7 @@ import { DownloadPlotButton } from '../general/DownloadPlotButton';
 import { getLabelOrUnknown } from '../general/utils';
 import { EColumnTypes, ICommonVisProps } from '../interfaces';
 import { SingleBarChart } from './SingleBarChart';
+import { FocusFacetSelector } from './barComponents/FocusFacetSelector';
 import { Legend } from './barComponents/Legend';
 import { useGetGroupedBarScales } from './hooks/useGetGroupedBarScales';
 import { IBarConfig, SortTypes } from './interfaces';
@@ -84,44 +83,7 @@ export function BarChart({
     <Stack pr="40px" flex={1} style={{ width: '100%', height: '100%' }}>
       {showDownloadScreenshot ? (
         <Center h="20px">
-          {config.facets && allUniqueFacetVals.length > 0 ? (
-            <Group gap={4}>
-              <Select
-                key={`focusFacetSelect_${config.focusFacetIndex}`}
-                placeholder="Select a focus facet"
-                data={allUniqueFacetVals}
-                value={allUniqueFacetVals[config.focusFacetIndex] || ''}
-                onChange={(value) => {
-                  setConfig({ ...config, focusFacetIndex: typeof value === 'string' ? allUniqueFacetVals.indexOf(value) : value });
-                }}
-                clearable
-              />
-              <Tooltip label="Focus on previous facet" position="top" withArrow>
-                <ActionIcon
-                  color="dvGray"
-                  variant="subtle"
-                  disabled={config.focusFacetIndex === null}
-                  onClick={() => {
-                    setConfig({ ...config, focusFacetIndex: (config.focusFacetIndex - 1 + allUniqueFacetVals.length) % allUniqueFacetVals.length });
-                  }}
-                >
-                  <FontAwesomeIcon icon={faChevronLeft} />
-                </ActionIcon>
-              </Tooltip>
-              <Tooltip label="Focus on next facet" position="top" withArrow>
-                <ActionIcon
-                  color="dvGray"
-                  variant="subtle"
-                  disabled={config.focusFacetIndex === null}
-                  onClick={() => {
-                    setConfig({ ...config, focusFacetIndex: (config.focusFacetIndex + 1) % allUniqueFacetVals.length });
-                  }}
-                >
-                  <FontAwesomeIcon icon={faChevronRight} />
-                </ActionIcon>
-              </Tooltip>
-            </Group>
-          ) : null}
+          {config.facets && allUniqueFacetVals.length > 0 ? <FocusFacetSelector config={config} setConfig={setConfig} facets={allUniqueFacetVals} /> : null}
           <DownloadPlotButton uniquePlotId={id} config={config} />
         </Center>
       ) : null}

--- a/src/vis/bar/BarChart.tsx
+++ b/src/vis/bar/BarChart.tsx
@@ -44,7 +44,9 @@ export function BarChart({
   }, [allColumns?.facetsColVals?.resolvedValues]);
 
   const filteredUniqueFacetVals = useMemo(() => {
-    return typeof config.focusFacetIndex === 'number' ? [allUniqueFacetVals[config.focusFacetIndex]] : allUniqueFacetVals;
+    return typeof config.focusFacetIndex === 'number' && config.focusFacetIndex < allUniqueFacetVals.length
+      ? [allUniqueFacetVals[config.focusFacetIndex]]
+      : allUniqueFacetVals;
   }, [allUniqueFacetVals, config.focusFacetIndex]);
 
   const { groupColorScale, groupedTable } = useGetGroupedBarScales(

--- a/src/vis/bar/BarVis.tsx
+++ b/src/vis/bar/BarVis.tsx
@@ -8,6 +8,7 @@ import { IBarConfig } from './interfaces';
 
 export function BarVis({
   config,
+  setConfig,
   columns,
   selectionCallback = () => null,
   selectedMap = {},
@@ -20,6 +21,7 @@ export function BarVis({
       {config.catColumnSelected ? (
         <BarChart
           config={config}
+          setConfig={setConfig}
           columns={columns}
           selectedMap={selectedMap}
           selectionCallback={selectionCallback}

--- a/src/vis/bar/README.md
+++ b/src/vis/bar/README.md
@@ -1,0 +1,13 @@
+# Bar plot configuration notes
+
+## Focus facet
+
+The focus facet mode is a feature that allows you to highlight a specific bar plot when faceting is enabled. This feature is useful when you want to focus on a specific facet and compare it with the rest of the facets. The focus facet mode is enabled by clicking on the bar plot title or selecting a category in the facet selector dialog. It will only show one bar plot at once. The focus facet mode can be disabled by clicking on the bar plot title again, or by deselecting the category via the selector dialog.
+
+To enable the focus facet selector, it needs to be enabled in the visConfig:
+
+```json
+showFocusFacetSelector: true
+```
+
+If you utilize a non-standard view header, please be referred to `barComponents/FocusFacetSelector.ts` to have a reference implementation that can be reused.

--- a/src/vis/bar/SingleBarChart.tsx
+++ b/src/vis/bar/SingleBarChart.tsx
@@ -11,6 +11,7 @@ import { useGetGroupedBarScales } from './hooks/useGetGroupedBarScales';
 import { getBarData } from './utils';
 import { EBarDirection, EBarDisplayType, EBarGroupingType, IBarConfig, SortTypes } from './interfaces';
 import { ESortStates } from '../general/SortIcon';
+import { getLabelOrUnknown } from '../general/utils';
 
 /**
  * Return the margin object and adjust the bottom offset which also defines the lenght of the rotated labels
@@ -25,8 +26,10 @@ const getMargin = (rotatAxisLabel: boolean) => ({
 });
 
 export function SingleBarChart({
+  index,
   allColumns,
   config,
+  setConfig,
   categoryFilter,
   title,
   selectedMap,
@@ -37,8 +40,10 @@ export function SingleBarChart({
   setSortType,
   legendHeight,
 }: {
+  index?: number;
   allColumns: Awaited<ReturnType<typeof getBarData>>;
   config: IBarConfig;
+  setConfig: (config: IBarConfig) => void;
   selectedMap: Record<string, boolean>;
   selectedList: string[];
   categoryFilter?: string;
@@ -118,7 +123,7 @@ export function SingleBarChart({
   );
 
   return (
-    <Box ref={ref} style={{ maxWidth: '100%', maxHeight: '100%', position: 'relative', overflow: 'hidden' }}>
+    <Box ref={ref} style={{ width: '100%', height: '100%', position: 'relative', overflow: 'hidden' }}>
       <Container
         fluid
         pl={0}
@@ -133,7 +138,7 @@ export function SingleBarChart({
       >
         <svg width={width} height={height}>
           <g>
-            {countScale && categoryScale ? (
+            {countScale && categoryScale && title !== undefined ? (
               <text
                 dominantBaseline="middle"
                 style={{ fontWeight: 500, fill: '#505459' }}
@@ -143,8 +148,11 @@ export function SingleBarChart({
                     ? (categoryScale.range()[0] + categoryScale.range()[1]) / 2
                     : (countScale.range()[0] + countScale.range()[1]) / 2
                 }, ${getMargin(rotateXAxisTicks).top - 20})`}
+                onClick={() => {
+                  setConfig({ ...config, focusFacetIndex: config.focusFacetIndex === index ? null : index });
+                }}
               >
-                {title}
+                {getLabelOrUnknown(title)}
               </text>
             ) : null}
             <rect

--- a/src/vis/bar/SingleBarChart.tsx
+++ b/src/vis/bar/SingleBarChart.tsx
@@ -141,7 +141,7 @@ export function SingleBarChart({
             {countScale && categoryScale && title !== undefined ? (
               <text
                 dominantBaseline="middle"
-                style={{ fontWeight: 500, fill: '#505459' }}
+                style={{ fontWeight: 500, fill: '#505459', cursor: 'pointer' }}
                 textAnchor="middle"
                 transform={`translate(${
                   config.direction === EBarDirection.VERTICAL

--- a/src/vis/bar/barComponents/FocusFacetSelector.tsx
+++ b/src/vis/bar/barComponents/FocusFacetSelector.tsx
@@ -11,7 +11,7 @@ export function FocusFacetSelector({ config, setConfig, facets }: Pick<ICommonVi
   }
 
   return (
-    <Group gap={4}>
+    <Group gap={4} wrap="nowrap">
       <Select
         key={`focusFacetSelect_${config.focusFacetIndex}`}
         placeholder="Select a focus facet"

--- a/src/vis/bar/barComponents/FocusFacetSelector.tsx
+++ b/src/vis/bar/barComponents/FocusFacetSelector.tsx
@@ -22,7 +22,7 @@ export function FocusFacetSelector({ config, setConfig, facets }: Pick<ICommonVi
         }}
         clearable
       />
-      <Tooltip label="Focus on previous facet" position="top" withArrow>
+      <Tooltip label="Previous facet" position="top" withArrow>
         <ActionIcon
           color="dvGray"
           variant="subtle"
@@ -34,7 +34,7 @@ export function FocusFacetSelector({ config, setConfig, facets }: Pick<ICommonVi
           <FontAwesomeIcon icon={faChevronLeft} />
         </ActionIcon>
       </Tooltip>
-      <Tooltip label="Focus on next facet" position="top" withArrow>
+      <Tooltip label="Next facet" position="top" withArrow>
         <ActionIcon
           color="dvGray"
           variant="subtle"

--- a/src/vis/bar/barComponents/FocusFacetSelector.tsx
+++ b/src/vis/bar/barComponents/FocusFacetSelector.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { ActionIcon, Group, Select, Tooltip } from '@mantine/core';
+import type { IBarConfig } from '../interfaces';
+import type { ICommonVisProps } from '../../interfaces';
+
+export function FocusFacetSelector({ config, setConfig, facets }: Pick<ICommonVisProps<IBarConfig>, 'config' | 'setConfig'> & { facets: string[] }) {
+  return (
+    <Group gap={4}>
+      <Select
+        key={`focusFacetSelect_${config.focusFacetIndex}`}
+        placeholder="Select a focus facet"
+        data={facets}
+        value={facets[config.focusFacetIndex] || ''}
+        onChange={(value) => {
+          setConfig({ ...config, focusFacetIndex: typeof value === 'string' ? facets.indexOf(value) : value });
+        }}
+        clearable
+      />
+      <Tooltip label="Focus on previous facet" position="top" withArrow>
+        <ActionIcon
+          color="dvGray"
+          variant="subtle"
+          disabled={config.focusFacetIndex === null}
+          onClick={() => {
+            setConfig({ ...config, focusFacetIndex: (config.focusFacetIndex - 1 + facets.length) % facets.length });
+          }}
+        >
+          <FontAwesomeIcon icon={faChevronLeft} />
+        </ActionIcon>
+      </Tooltip>
+      <Tooltip label="Focus on next facet" position="top" withArrow>
+        <ActionIcon
+          color="dvGray"
+          variant="subtle"
+          disabled={config.focusFacetIndex === null}
+          onClick={() => {
+            setConfig({ ...config, focusFacetIndex: (config.focusFacetIndex + 1) % facets.length });
+          }}
+        >
+          <FontAwesomeIcon icon={faChevronRight} />
+        </ActionIcon>
+      </Tooltip>
+    </Group>
+  );
+}

--- a/src/vis/bar/barComponents/FocusFacetSelector.tsx
+++ b/src/vis/bar/barComponents/FocusFacetSelector.tsx
@@ -6,6 +6,10 @@ import type { IBarConfig } from '../interfaces';
 import type { ICommonVisProps } from '../../interfaces';
 
 export function FocusFacetSelector({ config, setConfig, facets }: Pick<ICommonVisProps<IBarConfig>, 'config' | 'setConfig'> & { facets: string[] }) {
+  if (!config.facets && facets.length === 0) {
+    return null;
+  }
+
   return (
     <Group gap={4}>
       <Select

--- a/src/vis/bar/interfaces.ts
+++ b/src/vis/bar/interfaces.ts
@@ -34,6 +34,7 @@ export interface IBarConfig extends BaseVisConfig {
   catColumnSelected: ColumnInfo;
   aggregateType: EAggregateTypes;
   aggregateColumn: ColumnInfo | null;
+  showFocusFacetSelector: boolean;
 }
 
 export const defaultConfig: IBarConfig = {
@@ -48,6 +49,7 @@ export const defaultConfig: IBarConfig = {
   direction: EBarDirection.HORIZONTAL,
   aggregateColumn: null,
   aggregateType: EAggregateTypes.COUNT,
+  showFocusFacetSelector: false,
 };
 
 export function isBarConfig(s: BaseVisConfig): s is IBarConfig {

--- a/src/vis/bar/interfaces.ts
+++ b/src/vis/bar/interfaces.ts
@@ -25,6 +25,7 @@ export enum EBarDirection {
 export interface IBarConfig extends BaseVisConfig {
   type: ESupportedPlotlyVis.BAR;
   facets: ColumnInfo | null;
+  focusFacetIndex: number | null;
   group: ColumnInfo | null;
   direction: EBarDirection;
   display: EBarDisplayType;
@@ -42,6 +43,7 @@ export const defaultConfig: IBarConfig = {
   group: null,
   groupType: EBarGroupingType.STACK,
   facets: null,
+  focusFacetIndex: null,
   display: EBarDisplayType.ABSOLUTE,
   direction: EBarDirection.HORIZONTAL,
   aggregateColumn: null,


### PR DESCRIPTION
Closes #419 

### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Add focus facet component to toolbar
- Select focus facet on click on the title and return to overview if clicked again
- Cycling infinitely through all facets in focus mode

### Screenshots

[bar-chart-focus-facet.webm](https://github.com/user-attachments/assets/e05e39c7-605a-41fd-bc69-bea6d3d47d0d)


![image](https://github.com/user-attachments/assets/702aa27e-42d8-4f48-bed2-23d6c67f2c4c)

![image](https://github.com/user-attachments/assets/3e768ed6-3062-41fa-8208-595334234fa4)


### Additional notes for the reviewer(s)

The flag `showFocusFacetSelector` in the bar config is disabled by default and needs to be enabled on demand. We can decide whether or not to show it by default.

----
Thanks for creating this pull request 🤗
