### PR TITLE
feature: Add YAxis merged option to violin vis

### DIFF
--- a/src/vis/violin/ViolinSegmentedControl.tsx
+++ b/src/vis/violin/ViolinSegmentedControl.tsx
@@ -45,7 +45,17 @@ export function ViolinOverlaySegmentedControl({
   );
 }
 
-export function ViolinSyncYAxisSegmentedControl({ callback, currentSelected, disabled }: SegmentedControlProps<EYAxisMode>) {
+export function ViolinSyncYAxisSegmentedControl({
+  callback,
+  currentSelected,
+  disabled,
+  disableMerged,
+}: SegmentedControlProps<EYAxisMode> & { disableMerged?: boolean }) {
+  // If the merged option is disabled and the current selected is merged, change it to unsynced
+  if (disableMerged && currentSelected === EYAxisMode.MERGED) {
+    callback(EYAxisMode.UNSYNC);
+  }
+
   return (
     <Input.Wrapper
       label={
@@ -64,6 +74,7 @@ export function ViolinSyncYAxisSegmentedControl({ callback, currentSelected, dis
           data={[
             { label: EYAxisMode.UNSYNC, value: EYAxisMode.UNSYNC },
             { label: EYAxisMode.SYNC, value: EYAxisMode.SYNC },
+            { label: EYAxisMode.MERGED, value: EYAxisMode.MERGED, disabled: disableMerged },
           ]}
         />
       </Tooltip>

--- a/src/vis/violin/ViolinVisSidebar.tsx
+++ b/src/vis/violin/ViolinVisSidebar.tsx
@@ -90,6 +90,8 @@ export function ViolinVisSidebar({
               callback={(syncYAxis: EYAxisMode) => setConfig({ ...config, syncYAxis })}
               currentSelected={config.syncYAxis}
               disabled={config.numColumnsSelected.length < 2 && !config.facetBy}
+              // TODO: Enable merged when two or more numerical columns have the same score type (to be implemented in the future)
+              disableMerged={config.catColumnSelected !== null || config.numColumnsSelected.length < 2}
             />
           )
         : null}

--- a/src/vis/violin/interfaces.ts
+++ b/src/vis/violin/interfaces.ts
@@ -9,6 +9,7 @@ export enum EViolinOverlay {
 export enum EYAxisMode {
   UNSYNC = 'unsynced',
   SYNC = 'synced',
+  MERGED = 'merged',
 }
 
 export interface IViolinConfig extends BaseVisConfig {

--- a/src/vis/violin/utils.ts
+++ b/src/vis/violin/utils.ts
@@ -295,7 +295,7 @@ export async function createViolinTraces(
     const { plotId, facet, subCat, cat, num } = group[0].groups;
     const isSelected = selectedList.length > 0 && group.some((g) => selectedMap[g.ids]);
     const opacities = selectedList.length > 0 ? (isSelected ? baseOpacities.selected : baseOpacities.unselected) : baseOpacities.selected;
-    const patchedPlotId = facet ? numCols.length * uniqueFacetValues.indexOf(facet.val) + plotId : plotId;
+    const patchedPlotId = config.syncYAxis === EYAxisMode.MERGED ? 1 : facet ? numCols.length * uniqueFacetValues.indexOf(facet.val) + plotId : plotId;
     if (patchedPlotId > plotCounter) {
       plotCounter = patchedPlotId;
     }
@@ -351,10 +351,10 @@ export async function createViolinTraces(
         offsetgroup: subCat?.val,
         ...sharedData,
       },
-      yLabel: group[0].groups.num.id,
+      yLabel: config.syncYAxis === EYAxisMode.MERGED ? 'Merged axis' : group[0].groups.num.id,
       xLabel: catCol ? group[0].groups.cat.id : null,
       title: facetCol ? `${columnNameWithDescription(facetCol.info)} - ${group[0].groups.facet.val}` : null,
-      yDomain: config.syncYAxis === EYAxisMode.SYNC ? [dataRange.min, dataRange.max] : null,
+      yDomain: [EYAxisMode.SYNC, EYAxisMode.MERGED].includes(config.syncYAxis) ? [dataRange.min, dataRange.max] : null,
     });
   });
 


### PR DESCRIPTION
Closes https://github.com/datavisyn/bioinsight/issues/452

### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [x] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes
- added new y-axis option `merged` to violin vis
  - allows having a shared axis for multiple numerical columns
  - disabled if categorical column selected (users can still use the subcategory setting in combination with merged y-axis though)

### Screenshots
![image](https://github.com/user-attachments/assets/ca5b6ed2-541d-4373-bbc7-0ba091a5938b)

![image](https://github.com/user-attachments/assets/c9e26cab-fe8f-404a-8158-694cc9e24e3f)

![image](https://github.com/user-attachments/assets/ef50fe6a-d625-4f0b-b976-d0160132fff9)


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
