### PR TITLE
fix: scatter plot tooltip update

### DIFF
--- a/src/vis/scatter/ScatterVis.tsx
+++ b/src/vis/scatter/ScatterVis.tsx
@@ -112,6 +112,7 @@ export function ScatterVis({
   } = useAsync(createScatterTraces, [
     columns,
     config.numColumnsSelected,
+    config.labelColumns,
     config.facets,
     config.shape,
     config.color,
@@ -230,10 +231,8 @@ export function ScatterVis({
       dragmode: config.dragMode,
     };
 
-    setLayout({ ...layout, ...beautifyLayout(traces, innerLayout, layout, null, false) });
-    // WARNING: Do not update when layout changes, that would be an infinite loop.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [traces, config.dragMode, showLegend]);
+    setLayout((previous) => ({ ...previous, ...beautifyLayout(traces, innerLayout, previous, null, false) }));
+  }, [traces, config.dragMode, showLegend, showDragModeOptions, config.facets]);
 
   const plotsWithSelectedPoints = useMemo(() => {
     if (traces) {
@@ -288,6 +287,7 @@ export function ScatterVis({
 
     return [];
   }, [plotsWithSelectedPoints, traces]);
+
   return (
     <Stack gap={0} style={{ height: '100%', width: '100%' }} pos="relative">
       {showDragModeOptions || showDownloadScreenshot ? (

--- a/src/vis/scatter/ScatterVisSidebar.tsx
+++ b/src/vis/scatter/ScatterVisSidebar.tsx
@@ -88,6 +88,12 @@ export function ScatterVisSidebar({ config, optionsConfig, columns, filterCallba
             />
           )
         : null}
+      <MultiSelect
+        callback={(labelColumns: ColumnInfo[]) => setConfig({ ...config, labelColumns })}
+        columns={columns}
+        currentSelected={config.labelColumns || []}
+        label="Tooltip labels"
+      />
       <OpacitySlider
         callback={(e) => {
           if (config.alphaSliderVal !== e) {

--- a/src/vis/scatter/interfaces.ts
+++ b/src/vis/scatter/interfaces.ts
@@ -13,6 +13,7 @@ export interface IScatterConfig extends BaseVisConfig {
   facets: ColumnInfo | null;
   regressionLineOptions?: IRegressionLineOptions;
   showLegend?: boolean;
+  labelColumns?: ColumnInfo[];
 }
 
 export function isScatterConfig(s: BaseVisConfig): s is IScatterConfig {

--- a/src/vis/scatter/utils.ts
+++ b/src/vis/scatter/utils.ts
@@ -96,6 +96,7 @@ export function moveSelectedToFront(
 export async function createScatterTraces(
   columns: VisColumn[],
   numColumnsSelected: ColumnInfo[],
+  labelColumns: ColumnInfo[],
   facet: ColumnInfo,
   shape: ColumnInfo,
   color: ColumnInfo,
@@ -237,11 +238,11 @@ export async function createScatterTraces(
           ids: group.map((d) => d.ids),
           xaxis: plotCounter === 1 ? 'x' : `x${plotCounter}`,
           yaxis: plotCounter === 1 ? 'y' : `y${plotCounter}`,
-          hovertext: group.map(
-            (d) =>
-              `${idToLabelMapper(d.ids)}<br>${xLabel}: ${d.x}<br>${yLabel}: ${d.y}
-              ${colorCol ? `<br>${columnNameWithDescription(colorCol.info)}: ${getLabelOrUnknown(d.color)}` : ''}
-              ${shapeCol && shapeCol.info.id !== colorCol?.info.id ? `<br>${columnNameWithDescription(shapeCol.info)}: ${getLabelOrUnknown(d.shape)}` : ''}`,
+          hovertext: group.map((d) =>
+            `${idToLabelMapper(d.ids)}<br />${xLabel}: ${d.x}<br />${yLabel}: ${d.y}
+${(labelColumns ?? []).map((l) => `<br />${columnNameWithDescription(l)}: ${getLabelOrUnknown(d.facet)}`)}
+${colorCol ? `<br />${columnNameWithDescription(colorCol.info)}: ${getLabelOrUnknown(d.color)}` : ''}
+${shapeCol && shapeCol.info.id !== colorCol?.info.id ? `<br />${columnNameWithDescription(shapeCol.info)}: ${getLabelOrUnknown(d.shape)}` : ''}`.trim(),
           ),
           text: group.map((d) => idToLabelMapper(d.ids)),
           // @ts-ignore
@@ -287,11 +288,11 @@ export async function createScatterTraces(
         ids: validCols[0].resolvedValues.map((v) => v.id?.toString()),
         xaxis: plotCounter === 1 ? 'x' : `x${plotCounter}`,
         yaxis: plotCounter === 1 ? 'y' : `y${plotCounter}`,
-        hovertext: validCols[0].resolvedValues.map(
-          (v, i) =>
-            `${idToLabelMapper(v.id)}<br>${xLabel}: ${v.val}<br>${yLabel}: ${yDataVals[i]}
-            ${colorCol ? `<br>${columnNameWithDescription(colorCol.info)}: ${getLabelOrUnknown(colorCol.resolvedValues[i].val)}` : ''}
-            ${shapeCol && shapeCol.info.id !== colorCol?.info.id ? `<br>${columnNameWithDescription(shapeCol.info)}: ${getLabelOrUnknown(shapeCol.resolvedValues[i].val)}` : ''}`,
+        hovertext: validCols[0].resolvedValues.map((v, i) =>
+          `${idToLabelMapper(v.id)}<br />${xLabel}: ${v.val}<br />${yLabel}: ${yDataVals[i]}
+${(labelColumns ?? []).map((l) => `<br />${columnNameWithDescription(l)}: ${getLabelOrUnknown(v.val)}`)}
+${colorCol ? `<br />${columnNameWithDescription(colorCol.info)}: ${getLabelOrUnknown(colorCol.resolvedValues[i].val)}` : ''}
+${shapeCol && shapeCol.info.id !== colorCol?.info.id ? `<br />${columnNameWithDescription(shapeCol.info)}: ${getLabelOrUnknown(shapeCol.resolvedValues[i].val)}` : ''}`.trim(),
         ),
         text: validCols[0].resolvedValues.map((v) => idToLabelMapper(v.id)),
         // @ts-ignore
@@ -370,11 +371,11 @@ export async function createScatterTraces(
               ids: xCurr.resolvedValues.map((v) => v.id?.toString()),
               xaxis: plotCounter === 1 ? 'x' : `x${plotCounter}`,
               yaxis: plotCounter === 1 ? 'y' : `y${plotCounter}`,
-              hovertext: xCurr.resolvedValues.map(
-                (v, i) =>
-                  `${v.id}<br>${xLabel}: ${v.val}<br>${yLabel}: ${yCurr.resolvedValues[i].val}
-                ${colorCol ? `<br>${columnNameWithDescription(colorCol.info)}: ${getLabelOrUnknown(colorCol.resolvedValues[i].val)}` : ''}
-                ${shapeCol && shapeCol.info.id !== colorCol?.info.id ? `<br>${columnNameWithDescription(shapeCol.info)}: ${getLabelOrUnknown(shapeCol.resolvedValues[i].val)}` : ''}`,
+              hovertext: xCurr.resolvedValues.map((v, i) =>
+                `${v.id}<br />${xLabel}: ${v.val}<br />${yLabel}: ${yCurr.resolvedValues[i].val}
+${(labelColumns ?? []).map((l) => `${columnNameWithDescription(l)}: ${getLabelOrUnknown(v.val)}`)}
+${colorCol ? `<br />${columnNameWithDescription(colorCol.info)}: ${getLabelOrUnknown(colorCol.resolvedValues[i].val)}` : ''}
+${shapeCol && shapeCol.info.id !== colorCol?.info.id ? `<br />${columnNameWithDescription(shapeCol.info)}: ${getLabelOrUnknown(shapeCol.resolvedValues[i].val)}` : ''}`.trim(),
               ),
               text: validCols[0].resolvedValues.map((v) => idToLabelMapper(v.id)),
               // @ts-ignore

--- a/src/vis/sidebar/MultiSelect.tsx
+++ b/src/vis/sidebar/MultiSelect.tsx
@@ -7,15 +7,17 @@ export function MultiSelect({
   callback,
   columns,
   currentSelected,
-  columnType,
+  columnType = null,
+  label = '',
 }: {
   callback: (value: ColumnInfo[]) => void;
   columns: VisColumn[];
   currentSelected: ColumnInfo[];
-  columnType: EColumnTypes;
+  columnType?: EColumnTypes;
+  label?: string;
 }) {
   const filteredColumns = React.useMemo(() => {
-    return columns.filter((c) => c.type === columnType);
+    return columns.filter((c) => (columnType ? c.type === columnType : true));
   }, [columnType, columns]);
 
   const combobox = useCombobox({
@@ -118,7 +120,7 @@ export function MultiSelect({
             }
           `}
           rightSection={<CloseButton onMouseDown={handleValueRemoveAll} color="gray" variant="transparent" size={22} iconSize={12} tabIndex={-1} />}
-          label={`${columnType} columns`}
+          label={!label ? `${columnType} columns` : label}
           pointer
           onClick={() => combobox.toggleDropdown()}
         >


### PR DESCRIPTION
Closes #446

### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [x] Requires UI/UX/Vis review
  - [x] Reviewer(s) are notified @dvchristianbors @thinkh 
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes
- Added a `labelColumns` property to the Scatter plot config and a dropdown for the user to allow selecting the columns which should be displayed in the tooltip

### Screenshots
![446-scatter-plot-tooltip](https://github.com/user-attachments/assets/e2e2c457-eb48-474b-bd60-e7fcda3fdb20)


### Additional notes for the reviewer(s)
- The tooltip always shows the labelColumns at the end. This is a problem with plotly. I have discussed with @thinkh and we agreed that it is okay for the label columns to appear at the end.

![Screenshot from 2024-08-06 11-21-45](https://github.com/user-attachments/assets/194e6805-47ae-4254-a807-549d32b7326d)
