### PR TITLE
fix(vis-type: scatter): tooltip labels for facets in scatter plot

### DIFF
--- a/src/vis/scatter/utils.ts
+++ b/src/vis/scatter/utils.ts
@@ -239,11 +239,11 @@ export async function createScatterTraces(
           ids: group.map((d) => d.ids),
           xaxis: plotCounter === 1 ? 'x' : `x${plotCounter}`,
           yaxis: plotCounter === 1 ? 'y' : `y${plotCounter}`,
-          hovertext: group.map((d, i) =>
+          hovertext: group.map((d) =>
             `${idToLabelMapper(d.ids)}
 <br />${xLabel}: ${d.x}
 <br />${yLabel}: ${d.y}
-${(resolvedLabelColumns ?? []).map((l) => `<br />${columnNameWithDescription(l.info)}: ${getLabelOrUnknown(l.resolvedValues[i].val)}`)}
+${(resolvedLabelColumns ?? []).map((l) => `<br />${columnNameWithDescription(l.info)}: ${getLabelOrUnknown(l.resolvedValues.find((v) => String(v.id) === String(d.ids)).val)}`)}
 ${colorCol ? `<br />${columnNameWithDescription(colorCol.info)}: ${getLabelOrUnknown(d.color)}` : ''}
 ${shapeCol && shapeCol.info.id !== colorCol?.info.id ? `<br />${columnNameWithDescription(shapeCol.info)}: ${getLabelOrUnknown(d.shape)}` : ''}`.trim(),
           ),


### PR DESCRIPTION
Closes #446
### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [x] Requires UI/UX/Vis review
  - [x] Reviewer(s) are notified @thinkh 
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes
- Fixed tooltip label for facets in scatter plot

### Screenshots
- In single scatter plot

![Screenshot from 2024-08-07 16-16-00](https://github.com/user-attachments/assets/4cb8991f-714c-4609-8270-7f93e6ebeeab)

---

- In faceted scatter plot

![Screenshot from 2024-08-07 16-17-12](https://github.com/user-attachments/assets/9c68524d-52c2-4452-bd57-723197145d7f)
![Screenshot from 2024-08-07 16-16-11](https://github.com/user-attachments/assets/cfcae8d6-e1a9-4946-afa6-d9166e863c8b)

### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
