### PR TITLE
feat: return 401 if not logged in for loggedinas

### DIFF
--- a/src/security/LoginUtils.ts
+++ b/src/security/LoginUtils.ts
@@ -42,12 +42,7 @@ export class LoginUtils {
   }
 
   static loggedInAs(): Promise<IUser> {
-    return Ajax.send('/api/loggedinas', {}, 'POST').then((user: string | IUser) => {
-      if (typeof user !== 'string' && user.name) {
-        return user;
-      }
-      return Promise.reject('invalid');
-    });
+    return Ajax.send('/api/loggedinas', {}, 'POST');
   }
 
   static getStores(): Promise<IUserStore[]> {

--- a/visyn_core/security/jwt_router.py
+++ b/visyn_core/security/jwt_router.py
@@ -81,9 +81,11 @@ def logout():
 
 @jwt_router.get("/loggedinas")
 @jwt_router.post("/loggedinas")
-def loggedinas(request: Request):
+def loggedinas():
     user = manager.security.current_user
-    return user_to_dict(user, access_token=user.access_token) if user else '"not_yet_logged_in"'
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not logged in")
+    return user_to_dict(user, access_token=user.access_token)
 
 
 @jwt_router.get("/security/stores")

--- a/visyn_core/tests/test_security_login.py
+++ b/visyn_core/tests/test_security_login.py
@@ -9,12 +9,12 @@ from visyn_core.security.store.oauth2_security_store import create as create_oau
 
 
 def test_api_key(client: TestClient):
-    assert client.get("/api/loggedinas", headers={"apiKey": "invalid_user:password"}).json() == '"not_yet_logged_in"'
+    assert client.get("/api/loggedinas", headers={"apiKey": "invalid_user:password"}).status_code == 401
     assert client.get("/api/loggedinas", headers={"apiKey": "admin:admin"}).json()["name"] == "admin"
 
 
 def test_basic_authorization(client: TestClient):
-    assert client.get("/api/loggedinas", auth=("invalid_user", "password")).json() == '"not_yet_logged_in"'
+    assert client.get("/api/loggedinas", auth=("invalid_user", "password")).status_code == 401
     assert client.get("/api/loggedinas", auth=("admin", "admin")).json()["name"] == "admin"
 
 
@@ -33,8 +33,7 @@ def test_jwt_login(client: TestClient):
 
     # Check if we are actually not logged in
     response = client.get("/api/loggedinas")
-    assert response.status_code == 200
-    assert response.json() == '"not_yet_logged_in"'
+    assert response.status_code == 401
 
     # Login with the dummy user
     response = client.post("/api/login", data={"username": "admin", "password": "admin"})
@@ -81,8 +80,7 @@ def test_jwt_login(client: TestClient):
 
     # Check if we are actually not logged in anymore
     response = client.get("/api/loggedinas")
-    assert response.status_code == 200
-    assert response.json() == '"not_yet_logged_in"'
+    assert response.status_code == 401
 
 
 def test_jwt_token_location(client: TestClient):
@@ -96,18 +94,18 @@ def test_jwt_token_location(client: TestClient):
 
     # Does not work even though both header and cookies are passed
     response = client.get("/api/loggedinas", headers={"Authorization": f"Bearer {access_token}"})
-    assert response.json() == '"not_yet_logged_in"'
+    assert response.status_code == 401
 
     # Allow headers
     manager.settings.jwt_token_location = ["headers"]
 
     # Does not work as only headers are accepted
     response = client.get("/api/loggedinas")
-    assert response.json() == '"not_yet_logged_in"'
+    assert response.status_code == 401
 
     # Does work as header is passed
     response = client.get("/api/loggedinas", headers={"Authorization": f"Bearer {access_token}"})
-    assert response.json() == '"not_yet_logged_in"'
+    assert response.status_code == 401
 
     # Allow cookies
     manager.settings.jwt_token_location = ["cookies"]
@@ -153,7 +151,7 @@ def test_alb_security_store(client: TestClient):
 
     # Test if we are not logged in if we use invalid fields
     store.email_token_fields = ["field1", "field2"]
-    assert client.get("/api/loggedinas", headers=headers).json() == '"not_yet_logged_in"'
+    assert client.get("/api/loggedinas", headers=headers).status_code == 401
 
 
 def test_oauth2_security_store(client: TestClient):


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [x] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Currently we are returning a 200 with "'not_yet_logged_in'", which is quite confusing (also for tools like Sentry, as it triggers errors afterwards but the request is fine). Let's change it to actually trigger a 401 instead.
- Should be a patch because before it rejected a promise in this case, and now we just return the AjaxError instead.

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
