### PR TITLE
fix: add mantine carousel package to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.6.0",
     "@fortawesome/free-solid-svg-icons": "^6.6.0",
     "@fortawesome/react-fontawesome": "^0.2.2",
+    "@mantine/carousel": "~7.12.2",
     "@mantine/code-highlight": "~7.12.2",
     "@mantine/core": "~7.12.2",
     "@mantine/dates": "~7.12.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,9 +1,10 @@
 import { defineConfig, devices } from '@playwright/test';
+import { ChromaticConfig } from '@chromatic-com/playwright';
 
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
-export default defineConfig({
+export default defineConfig<ChromaticConfig>({
   testDir: './playwright',
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
@@ -21,6 +22,8 @@ export default defineConfig({
     screenshot: 'only-on-failure',
     /* Capture video */
     video: 'on-first-retry',
+    /* Chromatic: add delay to screenshot taking for more consistent results: https://www.chromatic.com/docs/playwright/configure/ */
+    delay: 300,
   },
   // increased as some tests are slow in CI (e.g. co-expression)
   expect: { timeout: 30000 },


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [ ] All acceptance criteria from the issue are met
- [ ] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [ ] Branch is up-to-date with the branch to be merged with, i.e., develop
- [ ] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [ ] Descriptive title for this pull request is provided (will be used for release notes later)
- [ ] Reviewer and assignees are defined
- [ ] Add type label (e.g., *bug*, *feature*) to this pull request
- [ ] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [ ] The PR is connected to the corresponding issue (via `Closes #...`)
- [ ] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- The Carousel component is used in ordino and as discussed the mantine packages should all be on core
for easies depdendency management
- Add properly typed playwright-chromatic configuration: https://www.chromatic.com/docs/playwright/configure/
  - Add delay for more consistent screenshots

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
