### PR TITLE
perf: Adjusted imports for echarts

### DIFF
--- a/src/vis/bar/SingleEChartsBarChart.tsx
+++ b/src/vis/bar/SingleEChartsBarChart.tsx
@@ -1,13 +1,13 @@
 import { Box } from '@mantine/core';
 import { useSetState } from '@mantine/hooks';
-import { type ScaleOrdinal } from 'd3v7';
-import { EChartsOption } from 'echarts';
+import type { ScaleOrdinal } from 'd3v7';
 import type { BarSeriesOption } from 'echarts/charts';
 import * as React from 'react';
 import { selectionColorDark } from '../../utils';
 import { DEFAULT_COLOR, NAN_REPLACEMENT, SELECT_COLOR, VIS_NEUTRAL_COLOR, VIS_UNSELECTED_OPACITY } from '../general';
 import { EAggregateTypes, ICommonVisProps } from '../interfaces';
 import { useChart } from '../vishooks/hooks/useChart';
+import type { ECOption } from '../vishooks/hooks/useChart';
 import { useBarSortHelper } from './hooks';
 import { EBarDirection, EBarDisplayType, EBarGroupingType, EBarSortParameters, EBarSortState, IBarConfig, SortDirectionMap } from './interfaces';
 import { AggregatedDataType, BAR_WIDTH, CHART_HEIGHT_MARGIN, median, normalizedValue, sortSeries } from './interfaces/internal';
@@ -47,8 +47,8 @@ function EagerSingleEChartsBarChart({
 }) {
   const [visState, setVisState] = useSetState({
     series: [] as BarSeriesOption[],
-    xAxis: null as EChartsOption['xAxis'] | null,
-    yAxis: null as EChartsOption['yAxis'] | null,
+    xAxis: null as ECOption['xAxis'] | null,
+    yAxis: null as ECOption['yAxis'] | null,
   });
 
   const hasSelected = React.useMemo(() => (selectedMap ? Object.values(selectedMap).some((selected) => selected) : false), [selectedMap]);
@@ -288,7 +288,7 @@ function EagerSingleEChartsBarChart({
           return name;
         },
       },
-    } as EChartsOption;
+    } as ECOption;
   }, [
     config?.aggregateColumn?.name,
     config?.aggregateType,
@@ -553,7 +553,7 @@ function EagerSingleEChartsBarChart({
       ...(visState.series ? { series: visState.series } : {}),
       ...(visState.xAxis ? { xAxis: visState.xAxis } : {}),
       ...(visState.yAxis ? { yAxis: visState.yAxis } : {}),
-    } as EChartsOption;
+    } as ECOption;
   }, [visState.series, visState.xAxis, visState.yAxis, optionBase]);
 
   // NOTE: @dv-usama-ansari: This effect is used to update the series data when the direction of the bar chart changes.

--- a/src/vis/vishooks/hooks/index.ts
+++ b/src/vis/vishooks/hooks/index.ts
@@ -7,4 +7,3 @@ export * from './useInteractions';
 export * from './useBrush';
 export * from './useLasso';
 export * from './useLinearScale';
-export * from './useChart';

--- a/src/vis/vishooks/hooks/useChart.ts
+++ b/src/vis/vishooks/hooks/useChart.ts
@@ -1,19 +1,33 @@
+/* eslint-disable react-compiler/react-compiler */
+import * as React from 'react';
 import { useSetState } from '@mantine/hooks';
-import * as echarts from 'echarts';
-import { ECElementEvent, ECharts, EChartsOption } from 'echarts';
-import { BarChart, LineChart, ScatterChart } from 'echarts/charts';
+import type { ECElementEvent, ECharts, ComposeOption } from 'echarts/core';
+import { use, init } from 'echarts/core';
+import { BarChart, LineChart } from 'echarts/charts';
 import { DataZoomComponent, GridComponent, LegendComponent, TitleComponent, ToolboxComponent, TooltipComponent } from 'echarts/components';
-import { use } from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';
-import React from 'react';
+import type {
+  // The series option types are defined with the SeriesOption suffix
+  BarSeriesOption,
+  LineSeriesOption,
+} from 'echarts/charts';
+import type {
+  // The component option types are defined with the ComponentOption suffix
+  TitleComponentOption,
+  TooltipComponentOption,
+  GridComponentOption,
+  DatasetComponentOption,
+} from 'echarts/components';
 import { useSetRef } from '../../../hooks';
 
-// Original code from https://dev.to/manufac/using-apache-echarts-with-react-and-typescript-optimizing-bundle-size-29l8
+export type ECOption = ComposeOption<
+  BarSeriesOption | LineSeriesOption | TitleComponentOption | TooltipComponentOption | GridComponentOption | DatasetComponentOption
+>;
 
+// Original code from https://dev.to/manufac/using-apache-echarts-with-react-and-typescript-optimizing-bundle-size-29l8
 // Register the required components
 use([
   LegendComponent,
-  ScatterChart,
   LineChart,
   BarChart,
   GridComponent,
@@ -60,7 +74,7 @@ export function useChart({
   settings,
   mouseEvents,
 }: {
-  options?: EChartsOption;
+  options?: ECOption;
   settings?: Parameters<ECharts['setOption']>[1];
   mouseEvents?: Partial<{ [K in ElementEventName]: CallbackArray | CallbackFunction | CallbackObject }>;
 }) {
@@ -123,7 +137,7 @@ export function useChart({
         setState({ width: newDimensions?.width, height: newDimensions?.height });
       });
       // create the instance
-      const instance = echarts.init(element);
+      const instance = init(element);
       // Save the mouse events
       syncEvents(instance);
       setState({ instance, internalObserver: observer });


### PR DESCRIPTION
By altering the way we import echarts, the bundle size could be reduced from ~9.8 to ~8.5mb. It is loaded when the vis loads. Lazy loading like in plotly is not possible with hooks. If the bundle size is still an issue we need to create a wrapper component like the LazyVis.

https://apache.github.io/echarts-handbook/en/basics/import/