### PR TITLE
Style: remove gray from categorical color palette

### DIFF
--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -1,5 +1,5 @@
 // categorical color map
-export const categoricalColors = ['#337AB7', '#ec6836', '#75c4c2', '#e9d36c', '#24b466', '#e891ae', '#db933c', '#b08aa6', '#8a6044', '#7b7b7b'];
+export const categoricalColors = ['#337AB7', '#ec6836', '#75c4c2', '#e9d36c', '#24b466', '#e891ae', '#db933c', '#b08aa6', '#8a6044'];
 
 // sequential color map blue
 export const sequentialBlueColors = ['#cff6ff', '#b0d6fe', '#93b9e8', '#779ecb', '#5c84af', '#406a94', '#23527a', '#023a60', '#002245'];


### PR DESCRIPTION
### Summary of changes

- Removing gray from the categorical color palette, as gray is our netural color which should be used for unknown categories only, or for visualizations without any categories.

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
