### PR TITLE
Style: Add new palettes for categorical colors

### DIFF
--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -4,10 +4,14 @@
  */
 export const categoricalColors = ['#337AB7', '#ec6836', '#75c4c2', '#e9d36c', '#24b466', '#e891ae', '#db933c', '#b08aa6', '#8a6044'];
 
-// categorical color map with 10 colors
+/**
+ * categorical color map with 10 colors
+ */
 export const categoricalColors10 = ['#337ab7', '#f75a1e', '#75c4c2', '#f0d034', '#15a154', '#e891ae', '#db933c', '#a380c4', '#a4c255', '#8c574b'];
 
-// categorical color map with 20 colors
+/**
+ * categorical color map with 20 colors
+ */
 export const categoricalColors20 = [
   '#337ab7',
   '#f75a1e',

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -1,5 +1,33 @@
 // categorical color map
+// @deprecated
 export const categoricalColors = ['#337AB7', '#ec6836', '#75c4c2', '#e9d36c', '#24b466', '#e891ae', '#db933c', '#b08aa6', '#8a6044'];
+
+// categorical color map with 10 colors
+export const categoricalColors10 = ['#337ab7', '#f75a1e', '#75c4c2', '#f0d034', '#15a154', '#e891ae', '#db933c', '#a380c4', '#a4c255', '#8c574b'];
+
+// categorical color map with 20 colors
+export const categoricalColors20 = [
+  '#337ab7',
+  '#f75a1e',
+  '#75c4c2',
+  '#f0d034',
+  '#15a154',
+  '#e891ae',
+  '#db933c',
+  '#a380c4',
+  '#a4c255',
+  '#8c574b',
+  '#73c1e9',
+  '#ffa087',
+  '#c1e8f6',
+  '#c0ffd2',
+  '#fabed4',
+  '#facea2',
+  '#dcbeff',
+  '#b2c8a8',
+  '#bf9890',
+  '#fff3b8',
+];
 
 // sequential color map blue
 export const sequentialBlueColors = ['#cff6ff', '#b0d6fe', '#93b9e8', '#779ecb', '#5c84af', '#406a94', '#23527a', '#023a60', '#002245'];

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -1,5 +1,7 @@
 // categorical color map
-// @deprecated
+/**
+ * @deprecated Use `categoricalColors10` instead.
+ */
 export const categoricalColors = ['#337AB7', '#ec6836', '#75c4c2', '#e9d36c', '#24b466', '#e891ae', '#db933c', '#b08aa6', '#8a6044'];
 
 // categorical color map with 10 colors


### PR DESCRIPTION
### Summary of changes

- new palette with 10 categorical colors
- new palette with 20 categorical colors (based on the 10 categorical colors above)
- the old categorial colors is deprecated

### Screenshots
10 colors:
![image](https://github.com/user-attachments/assets/39e249be-92da-48d4-a345-de0991a9d12d)


20 colors:
![image](https://github.com/user-attachments/assets/c14ad1b4-2cf2-409d-a50d-053b97749605)


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
