### PR TITLE
fix(vis-type: bar): jump to full width after rendering narrow initially using debounced resize observer

### DIFF
--- a/src/vis/vishooks/hooks/useChart.ts
+++ b/src/vis/vishooks/hooks/useChart.ts
@@ -1,6 +1,6 @@
 /* eslint-disable react-compiler/react-compiler */
 import * as React from 'react';
-import { useSetState } from '@mantine/hooks';
+import { useDebouncedCallback, useSetState } from '@mantine/hooks';
 import type { ECElementEvent, ECharts, ComposeOption } from 'echarts/core';
 import { use, init } from 'echarts/core';
 import { BarChart, LineChart } from 'echarts/charts';
@@ -85,6 +85,11 @@ export function useChart({
     instance: null as ECharts | null,
   });
 
+  const debouncedResizeObserver = useDebouncedCallback((entries: ResizeObserverEntry[]) => {
+    const newDimensions = entries[0]?.contentRect;
+    setState({ width: newDimensions?.width, height: newDimensions?.height });
+  }, 250);
+
   const mouseEventsRef = React.useRef(mouseEvents);
   mouseEventsRef.current = mouseEvents;
 
@@ -132,10 +137,7 @@ export function useChart({
 
   const { ref, setRef } = useSetRef<HTMLElement>({
     register: (element) => {
-      const observer = new ResizeObserver((entries) => {
-        const newDimensions = entries[0]?.contentRect;
-        setState({ width: newDimensions?.width, height: newDimensions?.height });
-      });
+      const observer = new ResizeObserver(debouncedResizeObserver);
       // create the instance
       const instance = init(element);
       // Save the mouse events


### PR DESCRIPTION
### Summary of changes

- cherry picked from commit 7818e9975369078df95158af091e15ef273f6083 that is part of https://github.com/datavisyn/visyn_core/pull/575

### Screenshots

[bar-chart-throttle-resize-observer.webm](https://github.com/user-attachments/assets/3ee3dfef-1db8-4d79-b07d-1a817b31ef4c)

### Additional notes for the reviewer(s)

I cherry picked the commit because it has by itself already a huge perceived performance impact. Using workers for aggregations and the remaining fixes will be merged with https://github.com/datavisyn/visyn_core/pull/575 and released afterwards.

---  
Thanks for creating this pull request 🤗
