### PR TITLE
fix: replace `categoricalColors` with `categoricalColors10`

### DIFF
--- a/playwright/boxPlot/04_subcategory.spec.ts
+++ b/playwright/boxPlot/04_subcategory.spec.ts
@@ -15,7 +15,7 @@ test('subcategory selected', async ({ page }) => {
 
   await expect(page.locator('g[class="subplot xy"]').locator('g[class="trace boxes"]').nth(1).locator('path[class="box"]')).toHaveCSS(
     'fill',
-    'rgb(236, 104, 54)',
+    'rgb(247, 90, 30)',
   );
 
   await expect(page.locator('g[class="subplot xy"]').locator('g[class="trace boxes"]').nth(2).locator('path[class="box"]')).toHaveCSS(

--- a/src/vis/scatter/ScatterVis.tsx
+++ b/src/vis/scatter/ScatterVis.tsx
@@ -21,7 +21,7 @@ import { i18n } from '../../i18n/I18nextManager';
 import { LegendItem } from '../general/LegendItem';
 import { useLayout } from './useLayout';
 import { useData } from './useData';
-import { categoricalColors, getCssValue } from '../../utils';
+import { categoricalColors10, getCssValue } from '../../utils';
 
 function Legend({ categories, colorMap, onClick }: { categories: string[]; colorMap: (v: number | string) => string; onClick: (string) => void }) {
   return (
@@ -348,7 +348,7 @@ export function ScatterVis({
       } else {
         // Create d3 color scale
         valuesWithoutUnknown.forEach((v, i) => {
-          mapping[v] = categoricalColors[i % categoricalColors.length]!;
+          mapping[v] = categoricalColors10[i % categoricalColors10.length]!;
         });
         mapping.Unknown = VIS_NEUTRAL_COLOR;
       }

--- a/src/vis/violin/utils.ts
+++ b/src/vis/violin/utils.ts
@@ -1,6 +1,6 @@
 import { cloneDeep, groupBy, mean, merge, orderBy, sumBy } from 'lodash';
 import { i18n } from '../../i18n';
-import { categoricalColors } from '../../utils';
+import { categoricalColors10 } from '../../utils';
 import { IBoxplotConfig } from '../boxplot';
 import { ESortStates } from '../general/SortIcon';
 import { NAN_REPLACEMENT, SELECT_COLOR, VIS_NEUTRAL_COLOR, VIS_UNSELECTED_OPACITY } from '../general/constants';
@@ -154,7 +154,7 @@ export async function createViolinTraces(
 
           if (!subCatMap[subCatVal]) {
             subCatMap[subCatVal] = {
-              color: subCatVal === NAN_REPLACEMENT ? VIS_NEUTRAL_COLOR : categoricalColors[Object.keys(subCatMap).length % categoricalColors.length],
+              color: subCatVal === NAN_REPLACEMENT ? VIS_NEUTRAL_COLOR : categoricalColors10[Object.keys(subCatMap).length % categoricalColors10.length],
               idx: Object.keys(subCatMap).length,
             };
           }
@@ -186,7 +186,7 @@ export async function createViolinTraces(
 
           if (!subCatMap[subCatVal]) {
             subCatMap[subCatVal] = {
-              color: subCatVal === NAN_REPLACEMENT ? VIS_NEUTRAL_COLOR : categoricalColors[Object.keys(subCatMap).length % categoricalColors.length],
+              color: subCatVal === NAN_REPLACEMENT ? VIS_NEUTRAL_COLOR : categoricalColors10[Object.keys(subCatMap).length % categoricalColors10.length],
               idx: Object.keys(subCatMap).length,
             };
           }
@@ -229,7 +229,7 @@ export async function createViolinTraces(
 
   // Create subcategory map for coloring and legend
   [...subCatOrder].forEach((v, i) => {
-    subCatMap[v] = { color: v === NAN_REPLACEMENT ? VIS_NEUTRAL_COLOR : categoricalColors[i % categoricalColors.length], idx: i };
+    subCatMap[v] = { color: v === NAN_REPLACEMENT ? VIS_NEUTRAL_COLOR : categoricalColors10[i % categoricalColors10.length], idx: i };
   });
 
   // Only allow split mode if there are exactly two subcategories and the plot type is violin


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [ ] All acceptance criteria from the issue are met
- [ ] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [ ] Branch is up-to-date with the branch to be merged with, i.e., develop
- [ ] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [ ] Descriptive title for this pull request is provided (will be used for release notes later)
- [ ] Reviewer and assignees are defined
- [ ] Add type label (e.g., *bug*, *feature*) to this pull request
- [ ] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [ ] The PR is connected to the corresponding issue (via `Closes #...`)
- [ ] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Replace the deprecated `categoricalColors` with `categoricalColors10` in scatter plot and violin plot

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
