### PR TITLE
fix(vis-type: bar): selection is lost when bar plot is sorted

### DIFF
--- a/src/vis/bar/SingleEChartsBarChart.tsx
+++ b/src/vis/bar/SingleEChartsBarChart.tsx
@@ -634,7 +634,6 @@ function EagerSingleEChartsBarChart({
             { sortState: config?.sortState as { x: EBarSortState; y: EBarSortState }, direction: EBarDirection.HORIZONTAL },
           );
           setVisState((v) => ({
-            ...v,
             // NOTE: @dv-usama-ansari: Reverse the data for horizontal bars to show the largest value on top for descending order and vice versa.
             series: barSeries.map((item, itemIndex) => ({
               ...item,
@@ -654,7 +653,6 @@ function EagerSingleEChartsBarChart({
           );
 
           setVisState((v) => ({
-            ...v,
             series: barSeries.map((item, itemIndex) => ({ ...item, data: sortedSeries[itemIndex]?.data })),
             xAxis: { ...v.xAxis, type: 'category' as const, data: sortedSeries[0]?.categories },
           }));
@@ -705,8 +703,6 @@ function EagerSingleEChartsBarChart({
 
     if (config?.direction === EBarDirection.HORIZONTAL) {
       setVisState((v) => ({
-        ...v,
-
         xAxis: {
           type: 'value' as const,
           name: aggregationAxisName,
@@ -744,8 +740,6 @@ function EagerSingleEChartsBarChart({
     }
     if (config?.direction === EBarDirection.VERTICAL) {
       setVisState((v) => ({
-        ...v,
-
         // NOTE: @dv-usama-ansari: xAxis is not showing labels as expected for the vertical bar chart.
         xAxis: {
           type: 'category' as const,

--- a/src/vis/bar/SingleEChartsBarChart.tsx
+++ b/src/vis/bar/SingleEChartsBarChart.tsx
@@ -420,38 +420,40 @@ function EagerSingleEChartsBarChart({
         {
           query: { seriesType: 'bar' },
           handler: (params) => {
-            const event = params.event?.event as unknown as React.MouseEvent<SVGGElement | HTMLDivElement, MouseEvent>;
-            // NOTE: @dv-usama-ansari: Sanitization is required here since the seriesName contains \u000 which make github confused.
-            const seriesName = sanitize(params.seriesName ?? '') === SERIES_ZERO ? params.name : params.seriesName;
-            const ids: string[] = config?.group
-              ? config.group.id === config?.facets?.id
-                ? [
-                    ...(aggregatedData?.categories[params.name]?.groups[selectedFacetValue!]?.unselected.ids ?? []),
-                    ...(aggregatedData?.categories[params.name]?.groups[selectedFacetValue!]?.selected.ids ?? []),
-                  ]
-                : [
-                    ...(aggregatedData?.categories[params.name]?.groups[seriesName as string]?.unselected.ids ?? []),
-                    ...(aggregatedData?.categories[params.name]?.groups[seriesName as string]?.selected.ids ?? []),
-                  ]
-              : (aggregatedData?.categories[params.name]?.ids ?? []);
+            if (params.componentType === 'series') {
+              const event = params.event?.event as unknown as React.MouseEvent<SVGGElement | HTMLDivElement, MouseEvent>;
+              // NOTE: @dv-usama-ansari: Sanitization is required here since the seriesName contains \u000 which make github confused.
+              const seriesName = sanitize(params.seriesName ?? '') === SERIES_ZERO ? params.name : params.seriesName;
+              const ids: string[] = config?.group
+                ? config.group.id === config?.facets?.id
+                  ? [
+                      ...(aggregatedData?.categories[params.name]?.groups[selectedFacetValue!]?.unselected.ids ?? []),
+                      ...(aggregatedData?.categories[params.name]?.groups[selectedFacetValue!]?.selected.ids ?? []),
+                    ]
+                  : [
+                      ...(aggregatedData?.categories[params.name]?.groups[seriesName as string]?.unselected.ids ?? []),
+                      ...(aggregatedData?.categories[params.name]?.groups[seriesName as string]?.selected.ids ?? []),
+                    ]
+                : (aggregatedData?.categories[params.name]?.ids ?? []);
 
-            if (event.shiftKey) {
-              // NOTE: @dv-usama-ansari: `shift + click` on a bar which is already selected will deselect it.
-              //  Using `Set` to reduce time complexity to O(1).
-              const newSelectedSet = new Set(selectedList);
-              ids.forEach((id) => {
-                if (newSelectedSet.has(id)) {
-                  newSelectedSet.delete(id);
-                } else {
-                  newSelectedSet.add(id);
-                }
-              });
-              const newSelectedList = [...newSelectedSet];
-              selectionCallback(event, [...new Set([...newSelectedList])]);
-            } else {
-              // NOTE: @dv-usama-ansari: Early return if the bar is clicked and it is already selected?
-              const isSameBarClicked = (selectedList ?? []).length > 0 && (selectedList ?? []).every((id) => ids.includes(id));
-              selectionCallback(event, isSameBarClicked ? [] : ids);
+              if (event.shiftKey) {
+                // NOTE: @dv-usama-ansari: `shift + click` on a bar which is already selected will deselect it.
+                //  Using `Set` to reduce time complexity to O(1).
+                const newSelectedSet = new Set(selectedList);
+                ids.forEach((id) => {
+                  if (newSelectedSet.has(id)) {
+                    newSelectedSet.delete(id);
+                  } else {
+                    newSelectedSet.add(id);
+                  }
+                });
+                const newSelectedList = [...newSelectedSet];
+                selectionCallback(event, [...new Set([...newSelectedList])]);
+              } else {
+                // NOTE: @dv-usama-ansari: Early return if the bar is clicked and it is already selected?
+                const isSameBarClicked = (selectedList ?? []).length > 0 && (selectedList ?? []).every((id) => ids.includes(id));
+                selectionCallback(event, isSameBarClicked ? [] : ids);
+              }
             }
           },
         },


### PR DESCRIPTION
Closes #600

### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [x] Requires UI/UX/Vis review
  - [x] Reviewer(s) are notified @thinkh @dvdanielamoitzi 
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes
- Fixed retaining selection when sort order is changed.

### Screenshots
[sort-selection-retain.webm](https://github.com/user-attachments/assets/74052826-7259-41eb-abb1-f8b6458a1d5e)


### Additional notes for the reviewer(s)
- It is necessary to use [fine grained pre-conditions](https://github.com/datavisyn/visyn_core/blob/58a3b595ba48d9296158adae2377b43ee3067a2a/src/vis/bar/SingleEChartsBarChart.tsx#L423) for the chart event listeners to dodge issues like these.