### PR TITLE
fix(vis-type: bar): axis labels when sort state is null

### DIFF
--- a/src/vis/bar/SingleEChartsBarChart.tsx
+++ b/src/vis/bar/SingleEChartsBarChart.tsx
@@ -681,9 +681,9 @@ function EagerSingleEChartsBarChart({
       : '';
     const aggregationAxisSortText =
       config?.direction === EBarDirection.HORIZONTAL
-        ? SortDirectionMap[config?.sortState?.x as EBarSortState]
+        ? SortDirectionMap[config?.sortState?.x ?? EBarSortState.NONE]
         : config?.direction === EBarDirection.VERTICAL
-          ? SortDirectionMap[config?.sortState?.y as EBarSortState]
+          ? SortDirectionMap[config?.sortState?.y ?? EBarSortState.NONE]
           : '';
     const aggregationAxisName = `${aggregationAxisNameBase}${aggregationAxisDescription} (${aggregationAxisSortText})`;
 
@@ -695,9 +695,9 @@ function EagerSingleEChartsBarChart({
       : '';
     const categoricalAxisSortText =
       config?.direction === EBarDirection.HORIZONTAL
-        ? SortDirectionMap[config?.sortState?.y as EBarSortState]
+        ? SortDirectionMap[config?.sortState?.y ?? EBarSortState.NONE]
         : config?.direction === EBarDirection.VERTICAL
-          ? SortDirectionMap[config?.sortState?.x as EBarSortState]
+          ? SortDirectionMap[config?.sortState?.x ?? EBarSortState.NONE]
           : '';
     const categoricalAxisName = `${categoricalAxisNameBase}${categoricalAxisDescription} (${categoricalAxisSortText})`;
 


### PR DESCRIPTION
Closes https://github.com/datavisyn/visyn_core/issues/596#issuecomment-2444085682

### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [x] Requires UI/UX/Vis review
  - [x] Reviewer(s) are notified @dvdanielamoitzi 
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes
- Fixed handling of null values for sort state

### Screenshots
![image](https://github.com/user-attachments/assets/7a5b81fc-dfcc-4906-a38d-7c4faf387083)


### Additional notes for the reviewer(s)
- N/A