### PR TITLE
fix: capturing a screenshot is broken for several visualizations

### DIFF
--- a/src/vis/correlation/CorrelationMatrix.tsx
+++ b/src/vis/correlation/CorrelationMatrix.tsx
@@ -190,26 +190,28 @@ export function CorrelationMatrix({
               <DownloadPlotButton uniquePlotId={id} config={config} />
             </Center>
           ) : null}
-          <Box pl={margin.left} pr={margin.right}>
-            <ColorLegendVert format=".3~g" scale={colorScale} width={availableSize} height={20} range={[-1, 1]} title="Correlation" />
-          </Box>
-          <Box ref={ref} style={{ height: '100%', width: `100%`, overflow: 'hidden' }}>
-            <svg style={{ height, width, overflow: 'hidden' }}>
-              <g transform={`translate(${(width - availableSize - margin.left - margin.right) / 2}, 0)`}>
-                {memoizedCorrelationResults?.map((value) => {
-                  return (
-                    <CorrelationPair
-                      key={`${value.xName}-${value.yName}`}
-                      value={value}
-                      fill={colorScale(value.correlation)}
-                      boundingRect={{ width: xScale.bandwidth(), height: yScale.bandwidth() }}
-                      config={config}
-                    />
-                  );
-                })}
-                {labelsDiagonal}
-              </g>
-            </svg>
+          <Box id={id} style={{ height: '100%', width: '100%' }}>
+            <Box pl={margin.left} pr={margin.right}>
+              <ColorLegendVert format=".3~g" scale={colorScale} width={availableSize} height={20} range={[-1, 1]} title="Correlation" />
+            </Box>
+            <Box ref={ref} style={{ height: '100%', width: `100%`, overflow: 'hidden' }}>
+              <svg style={{ height, width, overflow: 'hidden' }}>
+                <g transform={`translate(${(width - availableSize - margin.left - margin.right) / 2}, 0)`}>
+                  {memoizedCorrelationResults?.map((value) => {
+                    return (
+                      <CorrelationPair
+                        key={`${value.xName}-${value.yName}`}
+                        value={value}
+                        fill={colorScale(value.correlation)}
+                        boundingRect={{ width: xScale.bandwidth(), height: yScale.bandwidth() }}
+                        config={config}
+                      />
+                    );
+                  })}
+                  {labelsDiagonal}
+                </g>
+              </svg>
+            </Box>
           </Box>
         </Stack>
       ) : (

--- a/src/vis/correlation/CorrelationMatrix.tsx
+++ b/src/vis/correlation/CorrelationMatrix.tsx
@@ -184,7 +184,7 @@ export function CorrelationMatrix({
   return (
     <Stack pr="40px" style={{ height: '100%', width: '100%' }}>
       {status === 'success' ? (
-        <Stack align="center" gap={0} id={id} style={{ height: '100%', width: '100%' }}>
+        <Stack align="center" gap={0} style={{ height: '100%', width: '100%' }}>
           {showDownloadScreenshot ? (
             <Center>
               <DownloadPlotButton uniquePlotId={id} config={config} />

--- a/src/vis/hexbin/HexbinVis.tsx
+++ b/src/vis/hexbin/HexbinVis.tsx
@@ -13,7 +13,6 @@ import { getHexData } from './utils';
 import { LegendItem } from '../general/LegendItem';
 import { assignColorToNullValues } from '../general/utils';
 import { WarningMessage } from '../general/WarningMessage';
-import { DownloadPlotButton } from '../general/DownloadPlotButton';
 
 function Legend({
   categories,
@@ -116,7 +115,8 @@ export function HexbinVis({
                 dragMode={config.dragMode}
               />
             ) : null}
-            {showDownloadScreenshot && config.numColumnsSelected.length >= 2 ? <DownloadPlotButton uniquePlotId={id} config={config} /> : null}
+            {/* TODO: the download is broken right now because we are rendering an SVG, which is not supported
+            {showDownloadScreenshot && config.numColumnsSelected.length >= 2 ? <DownloadPlotButton uniquePlotId={id} config={config} /> : null} */}
           </Group>
         </Center>
       ) : null}

--- a/src/vis/hexbin/HexbinVis.tsx
+++ b/src/vis/hexbin/HexbinVis.tsx
@@ -13,6 +13,7 @@ import { getHexData } from './utils';
 import { LegendItem } from '../general/LegendItem';
 import { assignColorToNullValues } from '../general/utils';
 import { WarningMessage } from '../general/WarningMessage';
+import { DownloadPlotButton } from '../general/DownloadPlotButton';
 
 function Legend({
   categories,
@@ -115,8 +116,7 @@ export function HexbinVis({
                 dragMode={config.dragMode}
               />
             ) : null}
-            {/* TODO: the download is broken right now because we are rendering an SVG, which is not supported
-            {showDownloadScreenshot && config.numColumnsSelected.length >= 2 ? <DownloadPlotButton uniquePlotId={id} config={config} /> : null} */}
+            {showDownloadScreenshot && config.numColumnsSelected.length >= 2 ? <DownloadPlotButton uniquePlotId={id} config={config} /> : null}
           </Group>
         </Center>
       ) : null}

--- a/src/vis/scatter/ScatterVis.tsx
+++ b/src/vis/scatter/ScatterVis.tsx
@@ -2,6 +2,7 @@
 import { css } from '@emotion/css';
 import { Center, Group, ScrollArea, Stack, Switch, Tooltip } from '@mantine/core';
 import { useElementSize, useWindowEvent } from '@mantine/hooks';
+import uniqueId from 'lodash/uniqueId';
 import * as d3v7 from 'd3v7';
 import cloneDeep from 'lodash/cloneDeep';
 import uniq from 'lodash/uniq';
@@ -71,7 +72,7 @@ export function ScatterVis({
   uniquePlotId,
   showDownloadScreenshot,
 }: ICommonVisProps<IInternalScatterConfig>) {
-  const id = `ScatterVis_${React.useId()}`;
+  const id = React.useMemo(() => uniquePlotId || uniqueId('ScatterVis'), [uniquePlotId]);
 
   const [shiftPressed, setShiftPressed] = React.useState(false);
   const [showLegend, setShowLegend] = React.useState(false);
@@ -432,7 +433,6 @@ export function ScatterVis({
         grid-template-columns: 1fr fit-content(200px);
         grid-row-gap: 0.5rem;
       `}
-      id={id}
     >
       {showDragModeOptions || showDownloadScreenshot ? (
         <Center>

--- a/src/vis/useCaptureVisScreenshot.ts
+++ b/src/vis/useCaptureVisScreenshot.ts
@@ -89,7 +89,7 @@ export function useCaptureVisScreenshot(uniquePlotId: string, visConfig: BaseVis
           link.remove();
         }
       } else {
-        const dataUrl = await htmlToImage.toPng(plotElement.querySelector('canvas')!, {
+        const dataUrl = await htmlToImage.toPng(plotElement, {
           backgroundColor: 'white',
           cacheBust: true,
         });


### PR DESCRIPTION
Closes https://github.com/datavisyn/reprovisyn/issues/2125

### Developer Checklist (Definition of Done)

**Issue**

- [ ] All acceptance criteria from the issue are met
- [ ] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [ ] Branch is up-to-date with the branch to be merged with, i.e., develop
- [ ] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [ ] Descriptive title for this pull request is provided (will be used for release notes later)
- [ ] Reviewer and assignees are defined
- [ ] Add type label (e.g., *bug*, *feature*) to this pull request
- [ ] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [ ] The PR is connected to the corresponding issue (via `Closes #...`)
- [ ] [Summary of changes](#summary-of-changes) is written


### Summary of changes

#### Scatter plot
we were passing the id to both the parent and the plotly component + we were not using the `uniquePlotId `prop
#### Hex Bin plot
Was disabled, although the `useCaptureScreenshot` hook supports svgs
#### Heatmap
`useCaptureScreenshot` hook was expecting this to be rendered in a canvas which is not the case 
#### Correlation plot
Added the `plotId` to only download the plot and the legend and not the download plot button itself

... the rest of the plots worked already
### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
