### PR TITLE
Pinned @swc/core to 1.7.42

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,6 +145,9 @@
     "storybook": "^7.6.20",
     "storybook-addon-swc": "^1.2.0"
   },
+  "resolutions": {
+    "@swc/core": "1.7.42"
+  },
   "visyn": {
     "entries": {
       "app": {


### PR DESCRIPTION
Closes https://github.com/datavisyn/visyn_scripts/issues/104

For completeness the message of Slack explaining the issue:


>  I may have found the problem. storybook 7.6.20 has swc/core 1.9.0 as a dependency. since its the higher version it will be the top level node_modules version alongside with the jest version from visyn_scripts. swc/core for visyn_scripts is hoisted inside visyn_scripts node_modules. if storybook gets updated to 8 it does not have this dependency anymore and the tests will run again since no hoisting happens anymore (swc/core + swc/jest are only dependencies of visyn_scripts else!)
> This explains why resolutions work, but I believe then storybook would break.
> Also I do not know why this is a problem at all, but looking at the visyn_scripts command there are a lot of hardcoded ../../node_modules  paths so maybe it does not find the package when its hoisted. However if this is the case it should have been a problem for longer :lächeln:

A temporary solution is to pint @swc/core to the latest version so no hoisting happens until @puehringer updates storybook to v8 which has no dependencies on @swc/core
