### PR TITLE
deps: pin lineupengine as 2.5.3 breaks with scss errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "i18next": "^23.14.0",
     "jstat": "^1.9.6",
     "jszip": "^3.10.1",
+    "lineupengine": "2.5.2",
     "lineupjs": "4.11.0",
     "lodash": "~4.17.21",
     "plotly.js-dist-min": "~2.12.0",


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [ ] All acceptance criteria from the issue are met
- [ ] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [ ] Branch is up-to-date with the branch to be merged with, i.e., develop
- [ ] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [ ] Descriptive title for this pull request is provided (will be used for release notes later)
- [ ] Reviewer and assignees are defined
- [ ] Add type label (e.g., *bug*, *feature*) to this pull request
- [ ] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [ ] The PR is connected to the corresponding issue (via `Closes #...`)
- [ ] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- The lineupengine 2.5.3 release changed the way scss is loaded (i.e. `@import` -> `@use`), which breaks the override for the asset location. 

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
