### PR TITLE
fix: add back `showLabelLimit` option to scatter visualization

### DIFF
--- a/src/vis/scatter/ScatterVis.tsx
+++ b/src/vis/scatter/ScatterVis.tsx
@@ -18,7 +18,7 @@ import { VIS_NEUTRAL_COLOR } from '../general/constants';
 import { EColumnTypes, ENumericalColorScaleType, EScatterSelectSettings, ICommonVisProps } from '../interfaces';
 import { BrushOptionButtons } from '../sidebar/BrushOptionButtons';
 import { fitRegressionLine } from './Regression';
-import { ERegressionLineType, IInternalScatterConfig, IRegressionResult } from './interfaces';
+import { ERegressionLineType, IRegressionResult, IScatterConfig } from './interfaces';
 import { useData } from './useData';
 import { useDataPreparation } from './useDataPreparation';
 import { useLayout } from './useLayout';
@@ -71,7 +71,7 @@ export function ScatterVis({
   scrollZoom,
   uniquePlotId,
   showDownloadScreenshot,
-}: ICommonVisProps<IInternalScatterConfig>) {
+}: ICommonVisProps<IScatterConfig>) {
   const id = React.useMemo(() => uniquePlotId || uniqueId('ScatterVis'), [uniquePlotId]);
 
   const [shiftPressed, setShiftPressed] = React.useState(false);

--- a/src/vis/scatter/ScatterVisSidebar.tsx
+++ b/src/vis/scatter/ScatterVisSidebar.tsx
@@ -10,7 +10,7 @@ import { ColorSelect } from './ColorSelect';
 import { LabelingOptions } from './LabelingOptions';
 import { OpacitySlider } from './OpacitySlider';
 import { RegressionLineOptions } from './Regression';
-import { ELabelingOptions, IInternalScatterConfig, IRegressionLineOptions } from './interfaces';
+import { ELabelingOptions, IRegressionLineOptions, IScatterConfig } from './interfaces';
 
 const defaultConfig = {
   facets: {
@@ -40,7 +40,7 @@ const defaultConfig = {
   },
 };
 
-export function ScatterVisSidebar({ config, optionsConfig, columns, filterCallback, setConfig, selectedList }: ICommonVisSideBarProps<IInternalScatterConfig>) {
+export function ScatterVisSidebar({ config, optionsConfig, columns, filterCallback, setConfig, selectedList }: ICommonVisSideBarProps<IScatterConfig>) {
   const mergedOptionsConfig = useMemo(() => {
     return merge({}, defaultConfig, optionsConfig);
   }, [optionsConfig]);
@@ -113,7 +113,7 @@ export function ScatterVisSidebar({ config, optionsConfig, columns, filterCallba
                 }
               }}
               currentSelected={config.showLabels}
-              labelLimit={config.selectedPointsCount > config.showLabelLimit ? config.showLabelLimit : 0}
+              labelLimit={selectedList?.length && config.showLabelLimit && selectedList?.length > config.showLabelLimit ? config.showLabelLimit : 0}
             />
           )
         : null}

--- a/src/vis/scatter/interfaces.ts
+++ b/src/vis/scatter/interfaces.ts
@@ -30,16 +30,6 @@ export interface IScatterConfig extends BaseVisConfig {
   yAxisScale?: 'linear' | 'log';
 }
 
-/**
- * @internal
- */
-export interface IInternalScatterConfig extends IScatterConfig {
-  /**
-   * Internal property used to show a message if show labels mode is `Selected`
-   */
-  selectedPointsCount?: number;
-}
-
 export function isScatterConfig(s: BaseVisConfig): s is IScatterConfig {
   return s.type === ESupportedPlotlyVis.SCATTER;
 }

--- a/src/vis/scatter/useData.tsx
+++ b/src/vis/scatter/useData.tsx
@@ -71,7 +71,7 @@ export function useData({
     const fullOpacityOrAlpha = selectedSet.size > 0 ? 1 : config.alphaSliderVal;
 
     if (subplots) {
-      const visibleLabelsSet = new Set(selectedList.slice(0, config.showLabelLimit));
+      const visibleLabelsSet = config.showLabelLimit ? new Set(selectedList.slice(0, config.showLabelLimit)) : selectedSet;
       const plots = subplots.xyPairs.map((pair) => {
         return {
           ...BASE_DATA,
@@ -112,7 +112,7 @@ export function useData({
     }
 
     if (scatter && config && value && value.validColumns[0]) {
-      const visibleLabelsSet = new Set(selectedList.slice(0, config.showLabelLimit));
+      const visibleLabelsSet = config.showLabelLimit ? new Set(selectedList.slice(0, config.showLabelLimit)) : selectedSet;
       const traces = [
         {
           ...BASE_DATA,
@@ -158,7 +158,9 @@ export function useData({
 
     if (facet && config && value && value.validColumns[0] && value.validColumns[1]) {
       const plots = facet.resultData.map((group) => {
-        const visibleLabelsSet = new Set(group.data.ids.filter((id) => selectedSet.has(id)).slice(0, config.showLabelLimit));
+        const visibleLabelsSet = config.showLabelLimit
+          ? new Set(group.data.ids.filter((id) => selectedSet.has(id)).slice(0, config.showLabelLimit))
+          : selectedSet;
         return {
           ...BASE_DATA,
           type: 'scattergl',

--- a/src/vis/scatter/useData.tsx
+++ b/src/vis/scatter/useData.tsx
@@ -62,11 +62,12 @@ export function useData({
   shapeScale: (val: string) => string;
   mappingFunction?: (val: string | number | null | undefined) => string;
 }) {
+  const selectedSet = React.useMemo(() => new Set(selectedList), [selectedList]);
+
   return React.useMemo<PlotlyTypes.Data[]>(() => {
     if (status !== 'success' || !value) {
       return [];
     }
-    const selectedSet = new Set(selectedList);
     const fullOpacityOrAlpha = selectedSet.size > 0 ? 1 : config.alphaSliderVal;
 
     if (subplots) {
@@ -89,7 +90,7 @@ export function useData({
                   text: subplots.text.map((t) => truncateText(value.idToLabelMapper(t), true, 10)),
                 }
               : {
-                  text: subplots.text.map((t, i) => (visibleLabelsSet.has(subplots.ids[i] ?? '') ? truncateText(value.idToLabelMapper(t), true, 10) : '')),
+                  text: subplots.text.map((t, i) => (visibleLabelsSet.has(subplots.ids[i]!) ? truncateText(value.idToLabelMapper(t), true, 10) : '')),
                 }),
           hovertext: subplots.ids.map((p_id, index) =>
             `${value.idToLabelMapper(p_id)}
@@ -130,9 +131,7 @@ export function useData({
                   // textposition: 'top center',
                 }
               : {
-                  text: scatter.plotlyData.text.map((t, i) =>
-                    visibleLabelsSet.has(scatter.ids[i] ?? '') ? truncateText(value.idToLabelMapper(t), true, 10) : '',
-                  ),
+                  text: scatter.plotlyData.text.map((t, i) => (visibleLabelsSet.has(scatter.ids[i]!) ? truncateText(value.idToLabelMapper(t), true, 10) : '')),
                   // textposition: 'top center',
                 }),
           hovertext: value.validColumns[0].resolvedValues.map((v, i) =>
@@ -177,7 +176,7 @@ export function useData({
                   // textposition: 'top center',
                 }
               : {
-                  text: group.data.text.map((t, i) => (visibleLabelsSet.has(group.data.ids[i] ?? '') ? truncateText(value.idToLabelMapper(t), true, 10) : '')),
+                  text: group.data.text.map((t, i) => (visibleLabelsSet.has(group.data.ids[i]!) ? truncateText(value.idToLabelMapper(t), true, 10) : '')),
                   // textposition: 'top center',
                 }),
           name: getLabelOrUnknown(group.data.facet),
@@ -234,5 +233,5 @@ export function useData({
     }
 
     return [];
-  }, [status, value, subplots, scatter, config, facet, splom, selectedList, shapeScale, mappingFunction]);
+  }, [status, value, subplots, scatter, config, facet, splom, selectedList, selectedSet, shapeScale, mappingFunction]);
 }

--- a/src/vis/scatter/useData.tsx
+++ b/src/vis/scatter/useData.tsx
@@ -159,7 +159,7 @@ export function useData({
 
     if (facet && config && value && value.validColumns[0] && value.validColumns[1]) {
       const plots = facet.resultData.map((group) => {
-        const visibleLabelsSet = new Set(group.data.ids.filter((id) => selectedSet.has(id!)).slice(0, config.showLabelLimit));
+        const visibleLabelsSet = new Set(group.data.ids.filter((id) => selectedSet.has(id)).slice(0, config.showLabelLimit));
         return {
           ...BASE_DATA,
           type: 'scattergl',
@@ -177,7 +177,7 @@ export function useData({
                   // textposition: 'top center',
                 }
               : {
-                  text: group.data.text.map((t, i) => (visibleLabelsSet.has(group.data.ids[i]!) ? truncateText(value.idToLabelMapper(t), true, 10) : '')),
+                  text: group.data.text.map((t, i) => (visibleLabelsSet.has(group.data.ids[i] ?? '') ? truncateText(value.idToLabelMapper(t), true, 10) : '')),
                   // textposition: 'top center',
                 }),
           name: getLabelOrUnknown(group.data.facet),

--- a/src/vis/scatter/useData.tsx
+++ b/src/vis/scatter/useData.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import isEmpty from 'lodash/isEmpty';
 import { PlotlyTypes } from '../../plotly';
 import { DEFAULT_COLOR, VIS_NEUTRAL_COLOR } from '../general/constants';
-import { ELabelingOptions, IInternalScatterConfig } from './interfaces';
+import { ELabelingOptions, IScatterConfig } from './interfaces';
 import { FetchColumnDataResult } from './utils';
 import { getLabelOrUnknown } from '../general/utils';
 import { columnNameWithDescription, truncateText } from '../general/layoutUtils';
@@ -54,7 +54,7 @@ export function useData({
   status: string;
   value: FetchColumnDataResult | undefined;
   scatter?: ReturnType<typeof useDataPreparation>['scatter'];
-  config: IInternalScatterConfig;
+  config: IScatterConfig;
   facet?: ReturnType<typeof useDataPreparation>['facet'];
   splom?: ReturnType<typeof useDataPreparation>['splom'];
   subplots?: ReturnType<typeof useDataPreparation>['subplots'];
@@ -66,8 +66,11 @@ export function useData({
     if (status !== 'success' || !value) {
       return [];
     }
-    const fullOpacityOrAlpha = selectedList.length > 0 ? 1 : config.alphaSliderVal;
+    const selectedSet = new Set(selectedList);
+    const fullOpacityOrAlpha = selectedSet.size > 0 ? 1 : config.alphaSliderVal;
+
     if (subplots) {
+      const visibleLabelsSet = new Set(selectedList.slice(0, config.showLabelLimit));
       const plots = subplots.xyPairs.map((pair) => {
         return {
           ...BASE_DATA,
@@ -77,7 +80,7 @@ export function useData({
           xaxis: pair.xref,
           yaxis: pair.yref,
           textposition: subplots.text.map((_, i) => textPositionOptions[i % textPositionOptions.length]),
-          ...(isEmpty(selectedList) ? {} : { selectedpoints: selectedList.map((idx) => subplots.idToIndex.get(idx)) }),
+          ...(isEmpty(selectedSet) ? {} : { selectedpoints: selectedList.map((idx) => subplots.idToIndex.get(idx)) }),
           mode: config.showLabels === ELabelingOptions.NEVER || config.xAxisScale === 'log' || config.yAxisScale === 'log' ? 'markers' : 'text+markers',
           ...(config.showLabels === ELabelingOptions.NEVER
             ? {}
@@ -86,7 +89,7 @@ export function useData({
                   text: subplots.text.map((t) => truncateText(value.idToLabelMapper(t), true, 10)),
                 }
               : {
-                  text: subplots.text.map((t, i) => (selectedList.includes(subplots.ids[i] ?? '') ? truncateText(value.idToLabelMapper(t), true, 10) : '')),
+                  text: subplots.text.map((t, i) => (visibleLabelsSet.has(subplots.ids[i] ?? '') ? truncateText(value.idToLabelMapper(t), true, 10) : '')),
                 }),
           hovertext: subplots.ids.map((p_id, index) =>
             `${value.idToLabelMapper(p_id)}
@@ -108,6 +111,7 @@ export function useData({
     }
 
     if (scatter && config && value && value.validColumns[0]) {
+      const visibleLabelsSet = new Set(selectedList.slice(0, config.showLabelLimit));
       const traces = [
         {
           ...BASE_DATA,
@@ -116,7 +120,7 @@ export function useData({
           y: scatter.plotlyData.y,
           // text: scatter.plotlyData.text,
           textposition: scatter.plotlyData.text.map((_, i) => textPositionOptions[i % textPositionOptions.length]),
-          ...(isEmpty(selectedList) ? {} : { selectedpoints: selectedList.map((idx) => scatter.idToIndex.get(idx)) }),
+          ...(isEmpty(selectedSet) ? {} : { selectedpoints: selectedList.map((idx) => scatter.idToIndex.get(idx)) }),
           mode: config.showLabels === ELabelingOptions.NEVER || config.xAxisScale === 'log' || config.yAxisScale === 'log' ? 'markers' : 'text+markers',
           ...(config.showLabels === ELabelingOptions.NEVER
             ? {}
@@ -127,7 +131,7 @@ export function useData({
                 }
               : {
                   text: scatter.plotlyData.text.map((t, i) =>
-                    selectedList.includes(scatter.ids[i] ?? '') ? truncateText(value.idToLabelMapper(t), true, 10) : '',
+                    visibleLabelsSet.has(scatter.ids[i] ?? '') ? truncateText(value.idToLabelMapper(t), true, 10) : '',
                   ),
                   // textposition: 'top center',
                 }),
@@ -155,6 +159,7 @@ export function useData({
 
     if (facet && config && value && value.validColumns[0] && value.validColumns[1]) {
       const plots = facet.resultData.map((group) => {
+        const visibleLabelsSet = new Set(group.data.ids.filter((id) => selectedSet.has(id!)).slice(0, config.showLabelLimit));
         return {
           ...BASE_DATA,
           type: 'scattergl',
@@ -172,11 +177,11 @@ export function useData({
                   // textposition: 'top center',
                 }
               : {
-                  text: group.data.text.map((t, i) => (selectedList.includes(group.data.ids[i]!) ? truncateText(value.idToLabelMapper(t), true, 10) : '')),
+                  text: group.data.text.map((t, i) => (visibleLabelsSet.has(group.data.ids[i]!) ? truncateText(value.idToLabelMapper(t), true, 10) : '')),
                   // textposition: 'top center',
                 }),
           name: getLabelOrUnknown(group.data.facet),
-          ...(isEmpty(selectedList) ? {} : { selectedpoints: selectedList.map((idx) => group.idToIndex.get(idx)).filter((v) => v !== undefined) }),
+          ...(isEmpty(selectedSet) ? {} : { selectedpoints: selectedList.map((idx) => group.idToIndex.get(idx)).filter((v) => v !== undefined) }),
           hovertext: group.data.ids.map((p_id, index) =>
             `${value.idToLabelMapper(p_id)}
             ${(value.resolvedLabelColumnsWithMappedValues ?? []).map((l) => `<br />${columnNameWithDescription(l.info)}: ${getLabelOrUnknown(l.mappedValues.get(p_id))}`)}
@@ -214,7 +219,7 @@ export function useData({
   ${value.colorColumn ? `<br />${columnNameWithDescription(value.colorColumn.info)}: ${getLabelOrUnknown(value.colorColumn.resolvedValues[i]?.val)}` : ''}
   ${value.shapeColumn && value.shapeColumn.info.id !== value.colorColumn?.info.id ? `<br />${columnNameWithDescription(value.shapeColumn.info)}: ${getLabelOrUnknown(value.shapeColumn.resolvedValues[i]?.val)}` : ''}`.trim(),
           ),
-          ...(isEmpty(selectedList) ? {} : { selectedpoints: selectedList.map((idx) => splom.idToIndex.get(idx)) }),
+          ...(isEmpty(selectedSet) ? {} : { selectedpoints: selectedList.map((idx) => splom.idToIndex.get(idx)) }),
           marker: {
             size: 8,
             color: value.colorColumn && mappingFunction ? value.colorColumn.resolvedValues.map((v) => mappingFunction(v.val)) : VIS_NEUTRAL_COLOR,

--- a/src/vis/scatter/useLayout.tsx
+++ b/src/vis/scatter/useLayout.tsx
@@ -5,8 +5,8 @@ import { PlotlyTypes } from '../../plotly';
 import { VIS_NEUTRAL_COLOR, VIS_TRACES_COLOR } from '../general/constants';
 import { FastTextMeasure } from '../general/FastTextMeasure';
 import { getLabelOrUnknown } from '../general/utils';
-import { IInternalScatterConfig } from './interfaces';
 import { useDataPreparation } from './useDataPreparation';
+import { IScatterConfig } from './interfaces';
 
 const textMeasure = new FastTextMeasure('12px Open Sans');
 
@@ -87,7 +87,7 @@ export function useLayout({
   splom?: ReturnType<typeof useDataPreparation>['splom'];
   subplots?: ReturnType<typeof useDataPreparation>['subplots'];
   regressions: { shapes: Partial<PlotlyTypes.Shape>[]; annotations: Partial<PlotlyTypes.Annotations>[] };
-  config: IInternalScatterConfig;
+  config: IScatterConfig;
   width: number;
   height: number;
   internalLayoutRef: React.MutableRefObject<Partial<PlotlyTypes.Layout>>;


### PR DESCRIPTION
Closes *list issues numbers here*

### Developer Checklist (Definition of Done)

**Issue**

- [ ] All acceptance criteria from the issue are met
- [ ] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [ ] Branch is up-to-date with the branch to be merged with, i.e., develop
- [ ] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [ ] Descriptive title for this pull request is provided (will be used for release notes later)
- [ ] Reviewer and assignees are defined
- [ ] Add type label (e.g., *bug*, *feature*) to this pull request
- [ ] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [ ] The PR is connected to the corresponding issue (via `Closes #...`)
- [ ] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- added back the showLabelLimit option to the scatter plot

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
