### PR TITLE
fix: `@use` lineupengine vars to allow overriding them

### DIFF
--- a/src/scss/vendors/_lineup.scss
+++ b/src/scss/vendors/_lineup.scss
@@ -1,8 +1,11 @@
+// With https://github.com/lineupjs/lineupengine/releases/tag/v2.5.3, they changed from @import to @use, forcing us to use the variables before being able to override them.
+@use 'lineupengine/src/styles/vars' as *;
+
 // TODO: Without this, we get "Can't resolve './node_modules/lineupengine/src/styles/lineupengine/src/assets/loading.svg' in '.../workspaces/<repo>'"
 // Why do I need to do this? Probably because lineupjs defines $engine_assets and it is resolving it relatively?
 $engine_assets: '../assets';
-$engine_loading_image: url('#{$engine_assets}/loading.svg') !default;
-$engine_loading_static_image: url('#{$engine_assets}/loading_s.svg') !default;
+$engine_loading_image: url('#{$engine_assets}/loading.svg');
+$engine_loading_static_image: url('#{$engine_assets}/loading_s.svg');
 
 $lu_assets: '../assets' !default;
 $lu_use_font_awesome: true !default;


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- The lineupengine 2.5.3 release changed the way scss is loaded (i.e. `@import` -> `@use`), which breaks the override for the asset location.
- To now reassign the variables, we have to `@use` it before: https://sass-lang.com/documentation/at-rules/use/#reassigning-variables

### Screenshots
![image](https://github.com/user-attachments/assets/0ad3f866-42a0-4a08-91e2-dde103f835c8)


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
