### PR TITLE
feat: useTransformScale now supports ranged based transforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "visyn_core",
   "description": "Core repository for datavisyn applications.",
-  "version": "14.4.3",
+  "version": "14.4.4-SNAPSHOT",
   "author": {
     "name": "datavisyn GmbH",
     "email": "contact@datavisyn.io",

--- a/src/vis/vishooks/hooks/useTransformScale.ts
+++ b/src/vis/vishooks/hooks/useTransformScale.ts
@@ -29,7 +29,7 @@ export function useTransformScale({ domain, range, transform, direction, transfo
       };
     }
 
-    switch (transformTarget ?? 'domain') {
+    switch (transformTarget ?? (domain.length === 2 ? 'domain' : 'range')) {
       case 'domain':
         return {
           base: scale,
@@ -51,5 +51,5 @@ export function useTransformScale({ domain, range, transform, direction, transfo
 
     // We dont want to compare with range/domain reference, only the primitive values
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [domain?.[0], domain?.[1], range?.[0], range?.[1], transform, direction]);
+  }, [domain?.[0], domain?.[1], range?.[0], range?.[1], transform, direction, transformTarget]);
 }

--- a/src/vis/vishooks/hooks/useTransformScale.ts
+++ b/src/vis/vishooks/hooks/useTransformScale.ts
@@ -1,8 +1,8 @@
-import { useMemo } from 'react';
 import { ZoomTransform as D3ZoomTransform, scaleLinear } from 'd3v7';
 import { ZoomTransform } from '../interfaces';
 import { rescaleX, rescaleY } from '../transform';
 import { sxi, txi, tyi } from '../math/matrix4x4';
+import { useDeepMemo } from '../../../hooks/useDeepMemo';
 
 interface UseTransformScaleProps {
   domain: number[];
@@ -13,7 +13,7 @@ interface UseTransformScaleProps {
 }
 
 export function useTransformScale({ domain, range, transform, direction, transformTarget }: UseTransformScaleProps) {
-  return useMemo(() => {
+  return useDeepMemo(() => {
     // Invalid data case
     if (!domain || !range) {
       return null;
@@ -50,6 +50,5 @@ export function useTransformScale({ domain, range, transform, direction, transfo
     }
 
     // We dont want to compare with range/domain reference, only the primitive values
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [domain?.[0], domain?.[1], range?.[0], range?.[1], transform, direction, transformTarget]);
+  }, [domain, range, transform, direction, transformTarget]);
 }

--- a/src/vis/vishooks/hooks/useTransformScale.ts
+++ b/src/vis/vishooks/hooks/useTransformScale.ts
@@ -1,34 +1,53 @@
 import { useMemo } from 'react';
-import { scaleLinear } from 'd3-scale';
+import { ZoomTransform as D3ZoomTransform, scaleLinear } from 'd3v7';
 import { ZoomTransform } from '../interfaces';
 import { rescaleX, rescaleY } from '../transform';
+import { sxi, txi, tyi } from '../math/matrix4x4';
 
 interface UseTransformScaleProps {
   domain: number[];
   range: number[];
   transform?: ZoomTransform;
   direction: 'x' | 'y';
+  transformTarget?: 'domain' | 'range';
 }
 
-export function useTransformScale({ domain, range, transform, direction }: UseTransformScaleProps) {
+export function useTransformScale({ domain, range, transform, direction, transformTarget }: UseTransformScaleProps) {
   return useMemo(() => {
+    // Invalid data case
     if (!domain || !range) {
       return null;
     }
 
     const scale = scaleLinear().domain(domain).range(range);
 
-    if (transform) {
+    // Untransformed case
+    if (!transform) {
       return {
         base: scale,
-        scaled: direction === 'x' ? rescaleX(transform, scale) : rescaleY(transform, scale),
+        scaled: scale,
       };
     }
 
-    return {
-      base: scale,
-      scaled: scale,
-    };
+    switch (transformTarget ?? 'domain') {
+      case 'domain':
+        return {
+          base: scale,
+          scaled: direction === 'x' ? rescaleX(transform, scale) : rescaleY(transform, scale),
+        };
+      case 'range': {
+        const d3transform = new D3ZoomTransform(transform[sxi]!, transform[txi]!, transform[tyi]!);
+        const transformedRange =
+          direction === 'x' ? scale.range().map((value) => d3transform.applyX(value)) : scale.range().map((value) => d3transform.applyY(value));
+
+        return {
+          base: scale,
+          scaled: scale.copy().range(transformedRange),
+        };
+      }
+      default:
+        throw new Error('Invalid transform target');
+    }
 
     // We dont want to compare with range/domain reference, only the primitive values
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/vis/vishooks/hooks/useTransformScale.ts
+++ b/src/vis/vishooks/hooks/useTransformScale.ts
@@ -42,7 +42,7 @@ export function useTransformScale({ domain, range, transform, direction, transfo
 
         return {
           base: scale,
-          scaled: scale.copy().range(transformedRange),
+          scaled: scale.range(transformedRange),
         };
       }
       default:


### PR DESCRIPTION
Small explanation why this change is necessary:
In D3 the transform components are translation and scale, resulting in an affine linear transformation that can be applied to scales. For linear scales (that are not piecewise) the default is to transform the domain, since this has some benefits like knowing what the min/max of the currently visible part is. This however has the requirement that the scale is invertible from the range to the domain because to get an updated domain we first need to revert the range and then reapply the new domain to it. For piecewise scales, as well as ordinal scales, this is not possible because there is no 1:1 inversion, resulting in the jiggling behavior we observed.

The solution is to apply the transform to the range instead and letting the domain fixed. This works for all scales.

The fix is backwards compatible by specifying where the transform should be applied.