### PR TITLE
feat: Add skip/preventDefault conditions to useWheel

### DIFF
--- a/src/vis/vishooks/hooks/useWheel.ts
+++ b/src/vis/vishooks/hooks/useWheel.ts
@@ -11,6 +11,8 @@ export interface UseWheelProps {
    * Extent to constrain the wheel event within the bounds of the extent.
    */
   extent?: Extent;
+
+  preventDefault?: (event: NormalizedWheelEvent) => boolean;
 }
 
 /**
@@ -42,10 +44,14 @@ export function useWheel(props: UseWheelProps) {
           return;
         }
 
-        event.preventDefault();
+        const normalizedEvent = normalizeWheelEvent(event);
+
+        if (propsRef.current.preventDefault?.(normalizedEvent) ?? true) {
+          event.preventDefault();
+        }
 
         propsRef.current.onWheel?.({
-          ...normalizeWheelEvent(event),
+          ...normalizedEvent,
           x: relativePosition.x,
           y: relativePosition.y,
         });

--- a/src/vis/vishooks/hooks/useZoom.ts
+++ b/src/vis/vishooks/hooks/useZoom.ts
@@ -2,7 +2,7 @@ import { RefObject } from 'react';
 import { useWheel } from './useWheel';
 import { calculateTransform, defaultConstraint } from '../transform';
 import { useControlledUncontrolled } from './useControlledUncontrolled';
-import { Direction, Extent, ZoomExtent, ZoomTransform } from '../interfaces';
+import { Direction, Extent, NormalizedWheelEvent, ZoomExtent, ZoomTransform } from '../interfaces';
 import { m4 } from '../math';
 
 interface UseZoomProps {
@@ -34,6 +34,8 @@ interface UseZoomProps {
    * The transform origin.
    */
   transformOrigin?: [number, number];
+
+  preventDefault?: (event: NormalizedWheelEvent) => boolean;
 }
 
 /**
@@ -72,6 +74,7 @@ export function useZoom(options: UseZoomProps = {}) {
 
       setInternalValue(newZoom);
     },
+    preventDefault: options.preventDefault,
   });
 
   return { ref, setRef, transform: internalValue, setTransform: setInternalValue };

--- a/src/vis/vishooks/hooks/useZoom.ts
+++ b/src/vis/vishooks/hooks/useZoom.ts
@@ -36,6 +36,8 @@ interface UseZoomProps {
   transformOrigin?: [number, number];
 
   preventDefault?: (event: NormalizedWheelEvent) => boolean;
+
+  skip?: (event: NormalizedWheelEvent) => boolean;
 }
 
 /**
@@ -55,6 +57,10 @@ export function useZoom(options: UseZoomProps = {}) {
   const { ref, setRef } = useWheel({
     extent: options.extent,
     onWheel: (event) => {
+      if (options.skip?.(event) ?? false) {
+        return;
+      }
+
       let newZoom = calculateTransform(
         internalValue,
         event.x - (options.transformOrigin ? options.transformOrigin[0] : 0),

--- a/src/vis/vishooks/interfaces.ts
+++ b/src/vis/vishooks/interfaces.ts
@@ -9,6 +9,7 @@ export interface NormalizedWheelEvent {
   pixelY: number;
   x: number;
   y: number;
+  nativeEvent: WheelEvent;
 }
 
 export interface Brush {

--- a/src/vis/vishooks/normalizeWheelEvent.ts
+++ b/src/vis/vishooks/normalizeWheelEvent.ts
@@ -51,5 +51,6 @@ export function normalizeWheelEvent(
     pixelY,
     x: event.clientX,
     y: event.clientY,
+    nativeEvent: event,
   };
 }


### PR DESCRIPTION
Necessary for https://github.com/datavisyn/aevidence_pfizer_sync/issues/149

When having a visualization inside a canvas element that is scrollable, we want to have normal pan/zoom interactions when no modifiers are pressed and default browser behavior for the scrollbar when they are pressed.

This is possible by adding preventDefault for conditionally enabling/disabling browser behavior and skip for conditionally skipping the zoom calculation