### PR TITLE
Fix: typing for custom args in stories

### DIFF
--- a/src/vis/EagerVis.tsx
+++ b/src/vis/EagerVis.tsx
@@ -116,29 +116,7 @@ export function useRegisterDefaultVis(visTypes?: string[]) {
   }, [registerVisType, visTypes]);
 }
 
-export function EagerVis({
-  columns,
-  selected = [],
-  stats = undefined,
-  statsCallback = () => null,
-  colors = undefined,
-  shapes = DEFAULT_SHAPES,
-  selectionCallback = () => null,
-  filterCallback,
-  setExternalConfig = undefined,
-  closeCallback = () => null,
-  showCloseButton = false,
-  externalConfig = undefined,
-  enableSidebar = true,
-  showSidebar: internalShowSidebar,
-  showDragModeOptions = true,
-  setShowSidebar: internalSetShowSidebar,
-  showSidebarDefault = false,
-  scrollZoom = true,
-  visTypes,
-  uniquePlotId,
-  showDownloadScreenshot = false,
-}: {
+export interface VisProps {
   /**
    * Required data columns which are displayed.
    */
@@ -195,7 +173,31 @@ export function EagerVis({
    * Optional property to show the download screenshot button in the sidebar.
    */
   showDownloadScreenshot?: boolean;
-}) {
+}
+
+export function EagerVis({
+  columns,
+  selected = [],
+  stats = undefined,
+  statsCallback = () => null,
+  colors = undefined,
+  shapes = DEFAULT_SHAPES,
+  selectionCallback = () => null,
+  filterCallback,
+  setExternalConfig = undefined,
+  closeCallback = () => null,
+  showCloseButton = false,
+  externalConfig = undefined,
+  enableSidebar = true,
+  showSidebar: internalShowSidebar,
+  showDragModeOptions = true,
+  setShowSidebar: internalSetShowSidebar,
+  showSidebarDefault = false,
+  scrollZoom = true,
+  visTypes,
+  uniquePlotId,
+  showDownloadScreenshot = false,
+}: VisProps) {
   const [selectedList, setSelectedList] = useUncontrolled<string[]>({
     value: selected,
     defaultValue: [],

--- a/src/vis/stories/Vis/Bar/BarRandom.stories.tsx
+++ b/src/vis/stories/Vis/Bar/BarRandom.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { Meta, StoryObj } from '@storybook/react';
 
+import { VisProps } from '../../../EagerVis';
 import { Vis } from '../../../LazyVis';
 import { VisProvider } from '../../../Provider';
 import { EBarDirection, EBarDisplayType, EBarGroupingType, EBarSortState } from '../../../bar/interfaces';
@@ -197,12 +198,17 @@ function fetchData(numberOfPoints: number): VisColumn[] {
   ];
 }
 
-// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
-const meta: Meta<typeof Vis> = {
+interface CustomArgs {
+  pointCount: number;
+}
+
+// Merge the custom args with the component's props
+type MetaArgs = VisProps & CustomArgs;
+
+const meta: Meta<MetaArgs> = {
   title: 'Vis/vistypes/randomData/Bar',
   component: Vis,
   render: (args) => {
-    // @ts-ignore TODO: The pointCount is an injected property, but we are using typeof Vis such that this prop does not exist.
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const columns = React.useMemo(() => fetchData(args.pointCount), [args.pointCount]);
 
@@ -217,12 +223,13 @@ const meta: Meta<typeof Vis> = {
     );
   },
   argTypes: {
-    // @ts-ignore
     pointCount: { control: 'number' },
   },
   args: {
-    // @ts-ignore
     pointCount: 10000,
+  },
+  parameters: {
+    controls: { expanded: true },
   },
 };
 

--- a/src/vis/stories/Vis/Bar/BarRandom.stories.tsx
+++ b/src/vis/stories/Vis/Bar/BarRandom.stories.tsx
@@ -216,13 +216,13 @@ const meta: Meta<typeof Vis> = {
       </VisProvider>
     );
   },
-  parameters: {
-    argTypes: {
-      pointCount: { control: 'number' },
-    },
-    args: {
-      pointCount: 10000,
-    },
+  argTypes: {
+    // @ts-ignore
+    pointCount: { control: 'number' },
+  },
+  args: {
+    // @ts-ignore
+    pointCount: 10000,
   },
 };
 

--- a/src/vis/stories/Vis/Heatmap/HeatmapRandom.stories.tsx
+++ b/src/vis/stories/Vis/Heatmap/HeatmapRandom.stories.tsx
@@ -110,12 +110,14 @@ const meta: Meta<typeof Vis> = {
   component: Vis,
   parameters: {
     chromatic: { delay: 3000 },
-    argTypes: {
-      pointCount: { control: 'number' },
-    },
-    args: {
-      pointCount: 100000,
-    },
+  },
+  argTypes: {
+    // @ts-ignore
+    pointCount: { control: 'number' },
+  },
+  args: {
+    // @ts-ignore
+    pointCount: 100000,
   },
   render: (args) => {
     // @ts-ignore TODO: The pointCount is an injected property, but we are using typeof Vis such that this prop does not exist.

--- a/src/vis/stories/Vis/Hexbin/HexbinRandom.stories.tsx
+++ b/src/vis/stories/Vis/Hexbin/HexbinRandom.stories.tsx
@@ -81,16 +81,17 @@ function fetchData(numberOfPoints: number): VisColumn[] {
 }
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+
 const meta: Meta<typeof Vis> = {
   title: 'Vis/vistypes/randomData/Hexbin',
   component: Vis,
-  parameters: {
-    argTypes: {
-      pointCount: { control: 'number' },
-    },
-    args: {
-      pointCount: 10000,
-    },
+  argTypes: {
+    // @ts-ignore
+    pointCount: { control: 'number' },
+  },
+  args: {
+    // @ts-ignore
+    pointCount: 10000,
   },
   render: (args) => {
     // @ts-ignore TODO: The pointCount is an injected property, but we are using typeof Vis such that this prop does not exist.

--- a/src/vis/stories/Vis/Hexbin/HexbinRandom.stories.tsx
+++ b/src/vis/stories/Vis/Hexbin/HexbinRandom.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { Meta, StoryObj } from '@storybook/react';
 
+import { VisProps } from '../../../EagerVis';
 import { Vis } from '../../../LazyVis';
 import { VisProvider } from '../../../Provider';
 import { EHexbinOptions } from '../../../hexbin/interfaces';
@@ -80,21 +81,23 @@ function fetchData(numberOfPoints: number): VisColumn[] {
   ];
 }
 
-// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+interface CustomArgs {
+  pointCount: number;
+}
 
-const meta: Meta<typeof Vis> = {
+// Merge the custom args with the component's props
+type MetaArgs = VisProps & CustomArgs;
+
+const meta: Meta<MetaArgs> = {
   title: 'Vis/vistypes/randomData/Hexbin',
   component: Vis,
   argTypes: {
-    // @ts-ignore
     pointCount: { control: 'number' },
   },
   args: {
-    // @ts-ignore
     pointCount: 10000,
   },
   render: (args) => {
-    // @ts-ignore TODO: The pointCount is an injected property, but we are using typeof Vis such that this prop does not exist.
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const columns = React.useMemo(() => fetchData(args.pointCount), [args.pointCount]);
 

--- a/src/vis/stories/Vis/Scatter/ScatterRandom.stories.tsx
+++ b/src/vis/stories/Vis/Scatter/ScatterRandom.stories.tsx
@@ -93,13 +93,13 @@ function fetchData(numberOfPoints: number): VisColumn[] {
 const meta: Meta<typeof Vis> = {
   title: 'Vis/vistypes/randomData/Scatter',
   component: Vis,
-  parameters: {
-    argTypes: {
-      pointCount: { control: 'number' },
-    },
-    args: {
-      pointCount: 100000,
-    },
+  argTypes: {
+    // @ts-ignore
+    pointCount: { control: 'number' },
+  },
+  args: {
+    // @ts-ignore
+    pointCount: 100000,
   },
   render: (args) => {
     // @ts-ignore TODO: The pointCount is an injected property, but we are using typeof Vis such that this prop does not exist.

--- a/src/vis/stories/Vis/Scatter/ScatterRandom.stories.tsx
+++ b/src/vis/stories/Vis/Scatter/ScatterRandom.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { Meta, StoryObj } from '@storybook/react';
 
+import { VisProps } from '../../../EagerVis';
 import { Vis } from '../../../LazyVis';
 import { VisProvider } from '../../../Provider';
 import { BaseVisConfig, EColumnTypes, ENumericalColorScaleType, EScatterSelectSettings, ESupportedPlotlyVis, VisColumn } from '../../../interfaces';
@@ -89,20 +90,24 @@ function fetchData(numberOfPoints: number): VisColumn[] {
   ];
 }
 
+interface CustomArgs {
+  pointCount: number;
+}
+
+// Merge the custom args with the component's props
+type MetaArgs = VisProps & CustomArgs;
+
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
-const meta: Meta<typeof Vis> = {
+const meta: Meta<MetaArgs> = {
   title: 'Vis/vistypes/randomData/Scatter',
   component: Vis,
   argTypes: {
-    // @ts-ignore
     pointCount: { control: 'number' },
   },
   args: {
-    // @ts-ignore
     pointCount: 100000,
   },
   render: (args) => {
-    // @ts-ignore TODO: The pointCount is an injected property, but we are using typeof Vis such that this prop does not exist.
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const columns = React.useMemo(() => fetchData(args.pointCount), [args.pointCount]);
     // eslint-disable-next-line react-hooks/rules-of-hooks


### PR DESCRIPTION
Closes #689 

### Developer Checklist (Definition of Done)

**Issue**

- [ ] All acceptance criteria from the issue are met
- [ ] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [ ] Branch is up-to-date with the branch to be merged with, i.e., develop
- [ ] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [ ] Descriptive title for this pull request is provided (will be used for release notes later)
- [ ] Reviewer and assignees are defined
- [ ] Add type label (e.g., *bug*, *feature*) to this pull request
- [ ] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [ ] The PR is connected to the corresponding issue (via `Closes #...`)
- [ ] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Extracted the props of the EagerVis into an interface (VisProps) so that I can re-use it in the stories
- extended the Meta type by CustomArgs, where I included the pointCount
- Tested the stories and the MainApp, everything worked well

### Screenshots
**Barchart:**
![image](https://github.com/user-attachments/assets/0b67910f-6e22-411d-a6a1-ffca3950cb75)
**Heatmap:**
![image](https://github.com/user-attachments/assets/314420e5-16f3-4026-977e-cea29772dae8)
**Hexbin:**
![image](https://github.com/user-attachments/assets/1d97295b-2a0d-4e2d-b35d-c644745f6f97)


### Additional notes for the reviewer(s)
@puehringer I'm not sure if this has further indications on the vis component (maybe the typing?), as I extracted the interface from the function.


-  
Thanks for creating this pull request 🤗
