### PR TITLE
feat: add bundlesize check

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "./utils": "./src/utils/index.ts",
     "./views": "./src/views/index.ts",
     "./vis": "./src/vis/index.ts",
+    "./vis/lineupWrapper": "./src/vis/lineupWrapper/index.ts",
     "./icons": "./src/icons/index.ts",
     "./types": "./src/types.ts",
     "./assets/*": "./src/assets/*",
@@ -46,6 +47,12 @@
     "src",
     "dist"
   ],
+  "bundlesize": [
+    {
+      "path": "./bundles/app.*.js",
+      "maxSize": "500 kB"
+    }
+  ],
   "engines": {
     "npm": ">=8",
     "node": ">=16"
@@ -53,6 +60,7 @@
   "scripts": {
     "all": "yarn run lint:fix && yarn run test && yarn run build && yarn run dist",
     "build": "yarn run clean && yarn run compile && yarn run copy",
+    "bundlesize": "bundlesize",
     "clean": "visyn_scripts clean build dist lib",
     "compile:watch": "visyn_scripts compile --watch -p tsconfig.lenient.json",
     "compile": "visyn_scripts compile -p tsconfig.lenient.json",
@@ -73,7 +81,7 @@
     "storybook": "visyn_scripts storybook dev -p 6006",
     "test": "visyn_scripts test",
     "bundle:dev": "visyn_scripts bundle --mode development --env workspace_mode=single",
-    "bundle:prod": "visyn_scripts bundle --mode production --env workspace_mode=single",
+    "bundle:prod": "visyn_scripts bundle --mode production --env workspace_mode=single && yarn bundlesize",
     "chromatic": "yarn run chromatic"
   },
   "dependencies": {
@@ -119,7 +127,6 @@
     "plotly.js-dist-min": "~2.12.1",
     "react": "~18.3.1",
     "react-dom": "~18.3.1",
-    "react-highlight-words": "^0.20.0",
     "react-plotly.js": "^2.6.0",
     "react-spring": "^9.7.5",
     "react-window": "^1.8.11",
@@ -141,6 +148,7 @@
     "@storybook/react-webpack5": "^8.5.0",
     "@storybook/testing-library": "0.2.2",
     "@types/react-window": "^1.8.8",
+    "bundlesize": "^0.18.2",
     "chromatic": "^11.25.0",
     "storybook": "^8.5.0",
     "storybook-react-rsbuild": "^0.1.8"

--- a/src/components/HelpHoverCard.tsx
+++ b/src/components/HelpHoverCard.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons';
+import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons/faQuestionCircle';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ActionIcon, Group, Tooltip } from '@mantine/core';
 

--- a/src/components/PermissionChooser.tsx
+++ b/src/components/PermissionChooser.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { css } from '@emotion/css';
-import { faChevronDown } from '@fortawesome/free-solid-svg-icons';
+import { faChevronDown } from '@fortawesome/free-solid-svg-icons/faChevronDown';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Box, Button, Collapse, Group, Radio, SegmentedControl, Select, Stack, Text, TextInput, useMantineTheme } from '@mantine/core';
 import uniqueId from 'lodash/uniqueId';

--- a/src/demo/MainApp.tsx
+++ b/src/demo/MainApp.tsx
@@ -3,8 +3,8 @@ import * as React from 'react';
 import { Loader, Select, SimpleGrid, Stack, Text } from '@mantine/core';
 
 import { VisynApp, VisynHeader, useVisynAppContext } from '../app';
-import { DatavisynTaggle, VisynRanking, autosizeWithSMILESColumn } from '../ranking';
-import { defaultBuilder } from '../ranking/EagerVisynRanking';
+import type { DatavisynTaggle } from '../ranking';
+import { VisynRanking } from '../ranking/VisynRanking';
 import {
   BaseVisConfig,
   ELabelingOptions,
@@ -16,8 +16,9 @@ import {
   Vis,
 } from '../vis';
 import { MyCategoricalScore, MyLinkScore, MyNumberScore, MySMILESScore, MyStringScore } from './scoresUtils';
-import { breastCancerData } from '../vis/stories/breastCancerData';
-import { fetchBreastCancerData } from '../vis/stories/fetchBreastCancerData';
+
+const { breastCancerData } = await import('../vis/stories/breastCancerData');
+const { fetchBreastCancerData } = await import('../vis/stories/fetchBreastCancerData');
 
 export function MainApp() {
   const { user } = useVisynAppContext();
@@ -122,10 +123,10 @@ export function MainApp() {
               data={breastCancerData}
               selection={selection}
               setSelection={setSelection}
-              getBuilder={({ data }) => defaultBuilder({ data, smilesOptions: { setDynamicHeight: true } })}
+              // getBuilder={({ data }) => defaultBuilder({ data, smilesOptions: { setDynamicHeight: true } })}
               onBuiltLineUp={({ lineup }) => {
                 lineupRef.current = lineup;
-                autosizeWithSMILESColumn({ provider: lineup.data, lineup });
+                // autosizeWithSMILESColumn({ provider: lineup.data, lineup });
               }}
             />
           </Stack>

--- a/src/demo/scoresUtils.ts
+++ b/src/demo/scoresUtils.ts
@@ -1,10 +1,9 @@
-import { buildCategoricalColumn, buildNumberColumn, buildStringColumn } from 'lineupjs';
-
 import { randomSurnames } from './randomSurnames';
 import { IScoreResult } from '../ranking/score/interfaces';
 import { buildSMILESColumn } from '../ranking/smiles/SMILESColumnBuilder';
 
 export async function MyCategoricalScore(value: string): Promise<IScoreResult> {
+  const { buildCategoricalColumn } = await import('lineupjs');
   const data = new Array(5000).fill(0).map(() => (Math.random() * 10).toFixed(0));
 
   return {
@@ -14,6 +13,7 @@ export async function MyCategoricalScore(value: string): Promise<IScoreResult> {
 }
 
 export async function MyNumberScore(value: string): Promise<IScoreResult> {
+  const { buildNumberColumn } = await import('lineupjs');
   const data = new Array(5000).fill(0).map(() => Math.random() * 100);
 
   return {
@@ -32,6 +32,7 @@ export async function MySMILESScore(value: string): Promise<IScoreResult> {
 }
 
 export async function MyStringScore(value: string): Promise<IScoreResult> {
+  const { buildStringColumn } = await import('lineupjs');
   const data = new Array(5000).fill(0).map(() => randomSurnames[Math.floor(Math.random() * randomSurnames.length)]);
 
   return {
@@ -41,6 +42,7 @@ export async function MyStringScore(value: string): Promise<IScoreResult> {
 }
 
 export async function MyLinkScore(value: string): Promise<IScoreResult> {
+  const { buildStringColumn } = await import('lineupjs');
   const data = new Array(5000).fill(0).map(() => randomSurnames[Math.floor(Math.random() * randomSurnames.length)]);
 
   return {

--- a/src/icons/Icons.tsx
+++ b/src/icons/Icons.tsx
@@ -4,6 +4,7 @@ import { IconDefinition, IconName, IconPrefix } from '@fortawesome/fontawesome-c
  * Visualization icons
  */
 
+// TODO: Split this into multiple files to allow code splitting
 export const dvAddVisualization: IconDefinition = {
   prefix: 'dv' as IconPrefix,
   iconName: 'addVisualization' as IconName,

--- a/src/ranking/score/interfaces.ts
+++ b/src/ranking/score/interfaces.ts
@@ -1,4 +1,4 @@
-import { ColumnBuilder, IDataRow, IValueColumnDesc } from 'lineupjs';
+import type { ColumnBuilder, IDataRow, IValueColumnDesc } from 'lineupjs';
 
 /**
  * A single score result

--- a/src/ranking/score/utilities.ts
+++ b/src/ranking/score/utilities.ts
@@ -1,6 +1,6 @@
-import { IColumnDesc, IValueColumnDesc } from 'lineupjs';
+import type { IColumnDesc, IValueColumnDesc } from 'lineupjs';
 
-import { IScoreColumnDesc } from './interfaces';
+import type { IScoreColumnDesc } from './interfaces';
 
 export function isScoreColumnDesc<T = unknown>(desc: IValueColumnDesc<T> | IColumnDesc): desc is IScoreColumnDesc<T> {
   return !!(desc as any)?.scoreData;

--- a/src/ranking/smiles/SMILESColumn.tsx
+++ b/src/ranking/smiles/SMILESColumn.tsx
@@ -1,5 +1,5 @@
 import { Column, IDataRow, IValueColumnDesc, StringColumn, ValueColumn, toolbar } from 'lineupjs';
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 // internal function copied from lineupjs
 function integrateDefaults<T>(desc: T, defaults: Partial<T> = {}) {

--- a/src/ranking/smiles/SMILESFilterDialog.tsx
+++ b/src/ranking/smiles/SMILESFilterDialog.tsx
@@ -1,5 +1,5 @@
 import { ADialog, IDialogContext, IRankingHeaderContext, LocalDataProvider } from 'lineupjs';
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 
 import { ISMILESFilter, SMILESColumn } from './SMILESColumn';
 

--- a/src/ranking/smiles/utils.ts
+++ b/src/ranking/smiles/utils.ts
@@ -1,5 +1,5 @@
 import { ALineUp, Column, DataBuilder, IRankingHeaderContext, LocalDataProvider, defaultOptions, dialogContext } from 'lineupjs';
-import { uniqueId } from 'lodash';
+import uniqueId from 'lodash/uniqueId';
 
 import { SMILESColumn } from './SMILESColumn';
 import { SMILESFilterDialog } from './SMILESFilterDialog';

--- a/src/vis/VisSidebarWrapper.tsx
+++ b/src/vis/VisSidebarWrapper.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ReactNode } from 'react';
 
-import { faClose } from '@fortawesome/free-solid-svg-icons';
+import { faClose } from '@fortawesome/free-solid-svg-icons/faClose';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ActionIcon, Box, Divider, Group, ScrollArea, Stack, Text, Tooltip } from '@mantine/core';
 

--- a/src/vis/bar/components/FocusFacetSelector.tsx
+++ b/src/vis/bar/components/FocusFacetSelector.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { faChevronLeft } from '@fortawesome/free-solid-svg-icons/faChevronLeft';
+import { faChevronRight } from '@fortawesome/free-solid-svg-icons/faChevronRight';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ActionIcon, Group, Select, Tooltip } from '@mantine/core';
 

--- a/src/vis/correlation/CorrelationMatrix.tsx
+++ b/src/vis/correlation/CorrelationMatrix.tsx
@@ -6,7 +6,7 @@ import { useResizeObserver } from '@mantine/hooks';
 import * as d3 from 'd3v7';
 import { scaleBand } from 'd3v7';
 import { corrcoeff, spearmancoeff, tukeyhsd } from 'jstat';
-import { uniqueId } from 'lodash';
+import uniqueId from 'lodash/uniqueId';
 
 import { useAsync } from '../../hooks/useAsync';
 import { ColumnInfo, EColumnTypes, EScaleType, ICommonVisProps, VisCategoricalValue, VisNumericalValue } from '../interfaces';

--- a/src/vis/correlation/CorrelationVisSidebar.tsx
+++ b/src/vis/correlation/CorrelationVisSidebar.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons';
+import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons/faQuestionCircle';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ActionIcon, Group, Input, NumberInput, SegmentedControl, Text, Tooltip } from '@mantine/core';
 

--- a/src/vis/general/ErrorMessage.tsx
+++ b/src/vis/general/ErrorMessage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons';
+import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons/faExclamationCircle';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Alert, Center, Stack } from '@mantine/core';
 

--- a/src/vis/general/WarningMessage.tsx
+++ b/src/vis/general/WarningMessage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons';
+import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons/faExclamationCircle';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Alert, Center, Stack } from '@mantine/core';
 

--- a/src/vis/heatmap/HeatmapGrid.tsx
+++ b/src/vis/heatmap/HeatmapGrid.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { Center, Loader, Stack } from '@mantine/core';
-import { uniqueId } from 'lodash';
+import uniqueId from 'lodash/uniqueId';
 
 import { useAsync } from '../../hooks/useAsync';
 import { VisColumn } from '../interfaces';

--- a/src/vis/hexbin/HexbinVis.tsx
+++ b/src/vis/hexbin/HexbinVis.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { css } from '@emotion/css';
 import { Box, Center, Group, ScrollArea, Stack } from '@mantine/core';
 import * as d3v7 from 'd3v7';
-import { uniqueId } from 'lodash';
+import uniqueId from 'lodash/uniqueId';
 
 import { useAsync } from '../../hooks/useAsync';
 import { i18n } from '../../i18n';

--- a/src/vis/index.ts
+++ b/src/vis/index.ts
@@ -5,7 +5,6 @@
 // export * from './violin';
 // export * from './Vis';
 export * from './LazyVis';
-export * from './LineupVisWrapper';
 export * from './VisSidebar';
 export * from './general';
 export * from './interfaces';

--- a/src/vis/interfaces.ts
+++ b/src/vis/interfaces.ts
@@ -1,4 +1,4 @@
-import { PlotlyTypes } from '../plotly';
+import type { PlotlyTypes } from '../plotly';
 
 export enum ESupportedPlotlyVis {
   SCATTER = 'Scatter plot',

--- a/src/vis/lineupWrapper/LineupVisWrapper.ts
+++ b/src/vis/lineupWrapper/LineupVisWrapper.ts
@@ -3,10 +3,10 @@ import * as React from 'react';
 import { CategoricalColumn, Column, IDataRow, LocalDataProvider, NumberColumn, Ranking, ValueColumn } from 'lineupjs';
 import { createRoot } from 'react-dom/client';
 
-import { Vis } from './LazyVis';
-import { ColumnInfo, EColumnTypes, EFilterOptions, IVisCommonValue, VisColumn } from './interfaces';
-import { IRow } from '../base/interfaces';
-import { i18n } from '../i18n';
+import { IRow } from '../../base/interfaces';
+import { i18n } from '../../i18n';
+import { Vis } from '../LazyVis';
+import { ColumnInfo, EColumnTypes, EFilterOptions, IVisCommonValue, VisColumn } from '../interfaces';
 
 export class LineupVisWrapper {
   /**

--- a/src/vis/lineupWrapper/index.ts
+++ b/src/vis/lineupWrapper/index.ts
@@ -1,0 +1,1 @@
+export * from './LineupVisWrapper';

--- a/src/vis/sankey/SankeyVis.tsx
+++ b/src/vis/sankey/SankeyVis.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { css } from '@emotion/react';
 import { Center, Stack } from '@mantine/core';
-import { uniqueId } from 'lodash';
+import uniqueId from 'lodash/uniqueId';
 
 import { useAsync } from '../../hooks/useAsync';
 import { PlotlyComponent } from '../../plotly';

--- a/src/vis/sankey/utils.ts
+++ b/src/vis/sankey/utils.ts
@@ -1,4 +1,4 @@
-import { merge } from 'lodash';
+import merge from 'lodash/merge';
 
 import { ESupportedPlotlyVis, VisColumn } from '../interfaces';
 import { ISankeyConfig } from './interfaces';

--- a/src/vis/scatter/LabelingOptions.tsx
+++ b/src/vis/scatter/LabelingOptions.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { faCircleExclamation } from '@fortawesome/free-solid-svg-icons';
+import { faCircleExclamation } from '@fortawesome/free-solid-svg-icons/faCircleExclamation';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Group, Input, SegmentedControl, Stack, Text, ThemeIcon } from '@mantine/core';
 

--- a/src/vis/sidebar/utils.tsx
+++ b/src/vis/sidebar/utils.tsx
@@ -1,16 +1,4 @@
-import * as React from 'react';
-import Highlighter from 'react-highlight-words';
-
 import { ColumnInfo, VisCategoricalColumn, VisColumn, VisNumericalColumn } from '../interfaces';
-
-export const formatOptionLabel = (option, ctx) => {
-  return (
-    <>
-      <Highlighter searchWords={[ctx.inputValue]} autoEscape textToHighlight={option.name} />
-      {option.description && <span className="small text-muted ms-1">{option.description}</span>}
-    </>
-  );
-};
 
 export function getCol(columns: VisColumn[], info: ColumnInfo | null): VisNumericalColumn | VisCategoricalColumn | null {
   if (!info) {

--- a/src/vis/useCaptureVisScreenshot.ts
+++ b/src/vis/useCaptureVisScreenshot.ts
@@ -1,8 +1,6 @@
 import * as React from 'react';
 
 import { notifications } from '@mantine/notifications';
-import * as htmlToImage from 'html-to-image';
-import JSZip from 'jszip';
 
 import { IBarConfig } from './bar/interfaces';
 import { BaseVisConfig, EAggregateTypes, ESupportedPlotlyVis } from './interfaces';
@@ -22,6 +20,9 @@ export function useCaptureVisScreenshot(uniquePlotId: string, visConfig: BaseVis
       console.error('Could not find plot div to capture screenshot');
       return;
     }
+
+    const htmlToImage = await import('html-to-image');
+    const { default: JSZip } = await import('jszip');
 
     setIsLoading(true);
     setError(null);

--- a/src/vis/violin/utils.ts
+++ b/src/vis/violin/utils.ts
@@ -1,4 +1,9 @@
-import { cloneDeep, groupBy, mean, merge, orderBy, sumBy } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import groupBy from 'lodash/groupBy';
+import mean from 'lodash/mean';
+import merge from 'lodash/merge';
+import orderBy from 'lodash/orderBy';
+import sumBy from 'lodash/sumBy';
 
 import { i18n } from '../../i18n';
 import { categoricalColors10 } from '../../utils';

--- a/src/vis/vishooks/math/matrix4x4.ts
+++ b/src/vis/vishooks/math/matrix4x4.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-param-reassign */
 import { Matrix4x4, Vector3 } from './interfaces';
 
-export { Matrix4x4, Vector3 };
+export type { Matrix4x4, Vector3 };
 
 /**
  * A matrix in javascript notation is a 4x4 array of numbers.

--- a/src/vis/vishooks/math/vector3.ts
+++ b/src/vis/vishooks/math/vector3.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-param-reassign */
 import { Vector3 } from './interfaces';
 
-export { Vector3 };
+export type { Vector3 };
 
 export function vector3(out = new Float32Array(3)): Vector3 {
   out[0] = 0;

--- a/tests/exports.test.ts
+++ b/tests/exports.test.ts
@@ -6,7 +6,7 @@ import { readFileSync, readdirSync } from 'fs';
 import packageJson from '../package.json';
 
 const NOT_EXPORTED_PACKAGES = ['assets', 'demo', 'locales', 'scss', 'stories'];
-const ADDITIONAL_EXPORTS = ['.', './assets/*', './plotly/full', './scss/*', './phovea_registry', './package.json', './types'];
+const ADDITIONAL_EXPORTS = ['.', './assets/*', './plotly/full', './vis/lineupWrapper', './scss/*', './phovea_registry', './package.json', './types'];
 
 describe('package.json exports', () => {
   expect(packageJson.exports).toBeDefined();


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Adds basic bundle size check to avoid sudden increases due to wrong imports or so
- Checks the size of the `app` bundle (which is not even used by any app), but that's a good proxy for the vis and other libs. Better: create entrypoints for each export and check that individually.
- Fixes all lodash and fortawesome imports (i.e. to use `lodash/<name>`)
- Breaking change: moves the LineupWrapper to `visyn_core/vis/lineupWrapper` to code split lineup 

### Screenshots

Generated via `RSDOCTOR=true yarn bundle:prod` 

**Before:**

![image](https://github.com/user-attachments/assets/f12e880a-1618-4614-bd0a-8f5b5e61529d)


**After:**

![image](https://github.com/user-attachments/assets/30a965d3-252b-4b2a-a067-6393c94c13c4)



### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
