### PR TITLE
deps(pip): ease redis version range

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,8 @@ pyjwt[crypto]==2.9.0
 pytest-postgresql==6.1.1
 python-dateutil==2.9.0.post0
 requests==2.32.3
-redis>=5.0.0,<6.0.0
+# Redis versions according to https://github.com/celery/celery/blob/main/requirements/extras/redis.txt
+redis>=4.5.2,<6.0.0,!=4.5.5
 sentry-sdk~=2.19.2
 SQLAlchemy>=1.4.40,<=1.4.53
 starlette-context==0.3.6


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [ ] All acceptance criteria from the issue are met
- [ ] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [ ] Branch is up-to-date with the branch to be merged with, i.e., develop
- [ ] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [ ] Descriptive title for this pull request is provided (will be used for release notes later)
- [ ] Reviewer and assignees are defined
- [ ] Add type label (e.g., *bug*, *feature*) to this pull request
- [ ] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [ ] The PR is connected to the corresponding issue (via `Closes #...`)
- [ ] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Use same version range as [Celery](https://github.com/celery/celery/blob/main/requirements/extras/redis.txt)
- Allowing versions from redis >4.5 allows us to install visyn_core alongside Apache Superset

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
