### PR TITLE
fix: removed use-deep-compare-effect, removed Awaited type

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,6 @@
     "react-plotly.js": "^2.6.0",
     "react-spring": "^9.7.5",
     "react-window": "^1.8.11",
-    "use-deep-compare-effect": "^1.8.1",
     "visyn_scripts": "^12.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
- Removed **use-deep-compare-effect** from package.json, since we have our own version
- Removed Awaited<T> type, since TS 4.5 has an inbuilt one
- Moved 4 individual state properties to one common object, to remove flaky behavior (double renders with out-of-sync values) in case React will not batch the setStates