### PR TITLE
feat: add waitForClientConfig flag to allow skipping the wait for the clientConfig

### DIFF
--- a/src/demo/index.initialize.tsx
+++ b/src/demo/index.initialize.tsx
@@ -8,7 +8,7 @@ import { VisynAppProvider } from '../app/VisynAppProvider';
 // create a new instance of the app
 createRoot(document.getElementById('main')!).render(
   <React.StrictMode>
-    <VisynAppProvider appName="Demo App" disableMantine6>
+    <VisynAppProvider appName="Demo App" disableMantine6 waitForClientConfig={false}>
       <MainApp />
     </VisynAppProvider>
   </React.StrictMode>,


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Adds waitForClientConfig option for VisynAppProvider. Set this to false to skip the wait for the client config. This is useful if the app works even without the client config.
- Default remains true to wait for the clientConfig, so you can gradually migrate apps to load the app while the clientConfig is not initialized.

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
