### PR TITLE
feat: add arbitrary properties to user object, i.e. mapped from the JWT payload

### DIFF
--- a/src/app/header/VisynHeader.stories.tsx
+++ b/src/app/header/VisynHeader.stories.tsx
@@ -10,6 +10,7 @@ import { VisynHeader } from './VisynHeader';
 const user: IUser = {
   name: 'Jaimy Smith',
   roles: [],
+  properties: {},
 };
 
 const customerLogo = (

--- a/src/security/constants.ts
+++ b/src/security/constants.ts
@@ -1,7 +1,7 @@
 import { IUser } from './interfaces';
 
 export class UserUtils {
-  static ANONYMOUS_USER: IUser = { name: 'anonymous', roles: ['anonymous'] };
+  static ANONYMOUS_USER: IUser = { name: 'anonymous', roles: ['anonymous'], properties: {} };
 }
 
 export enum EPermission {

--- a/src/security/interfaces.ts
+++ b/src/security/interfaces.ts
@@ -26,6 +26,10 @@ export interface IUser {
    * list of roles the user is associated with
    */
   readonly roles: string[];
+  /**
+   * arbitrary properties mapped to the user, i.e. from a JWT token payload
+   */
+  properties: Record<string, unknown>;
 }
 
 export interface IUserStore<T extends Record<string, any> = Record<string, any>> {

--- a/visyn_core/security/manager.py
+++ b/visyn_core/security/manager.py
@@ -64,6 +64,7 @@ def user_to_dict(user: User, access_token: str | None = None, payload: dict | No
         "payload": payload,
         "access_token": access_token,
         "token_type": "bearer" if access_token else None,
+        "properties": user.properties,
     }
 
 

--- a/visyn_core/security/model.py
+++ b/visyn_core/security/model.py
@@ -27,6 +27,10 @@ class User(BaseModel):
     OAuth2 access token as many security stores (like ALB or OAuth2) only parse an already existing access token from an IdP.
     This token can then be used for downstream tasks like requests to other services.
     """
+    properties: dict[str, Any] = {}
+    """
+    Arbitary properties that are mapped to the user, i.e. from the JWT token to the user object.
+    """
 
     @property
     def name(self):

--- a/visyn_core/security/store/alb_security_store.py
+++ b/visyn_core/security/store/alb_security_store.py
@@ -28,6 +28,7 @@ class ALBSecurityStore(BaseStore):
         cookie_name: str | None,
         signout_url: str | None,
         email_token_field: str | list[str],
+        properties_fields: list[str],
         audience: str | list[str] | None,
         issuer: str | None,
         decode_options: dict[str, Any] | None,
@@ -37,6 +38,7 @@ class ALBSecurityStore(BaseStore):
         self.cookie_name = cookie_name
         self.signout_url = signout_url
         self.email_token_fields = [email_token_field] if isinstance(email_token_field, str) else email_token_field
+        self.properties_fields = properties_fields
         self.audience = audience
         self.issuer = issuer
         self.decode_options = decode_options
@@ -80,6 +82,7 @@ class ALBSecurityStore(BaseStore):
                     id=id,
                     roles=user.get("roles", []),
                     oauth2_access_token=access_token,
+                    properties={key: user.get(key) for key in self.properties_fields},
                 )
             except Exception:
                 _log.exception("Error in load_from_request")
@@ -111,6 +114,7 @@ def create():
             cookie_name=manager.settings.visyn_core.security.store.alb_security_store.cookie_name,
             signout_url=manager.settings.visyn_core.security.store.alb_security_store.signout_url,
             email_token_field=manager.settings.visyn_core.security.store.alb_security_store.email_token_field,
+            properties_fields=manager.settings.visyn_core.security.store.alb_security_store.properties_fields,
             audience=manager.settings.visyn_core.security.store.alb_security_store.audience,
             decode_options=manager.settings.visyn_core.security.store.alb_security_store.decode_options,
             region=manager.settings.visyn_core.security.store.alb_security_store.region,

--- a/visyn_core/security/store/no_security_store.py
+++ b/visyn_core/security/store/no_security_store.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 from ... import manager
 from ..model import User
@@ -8,12 +9,13 @@ _log = logging.getLogger(__name__)
 
 
 class NoSecurityStore(BaseStore):
-    def __init__(self, user: str, roles: list[str]):
+    def __init__(self, user: str, roles: list[str], properties: dict[str, Any]):
         self.user = user
         self.roles = roles
+        self.properties = properties
 
     def load_from_request(self, req):
-        return User(id=self.user, roles=self.roles)
+        return User(id=self.user, roles=self.roles, properties=self.properties)
 
 
 def create():
@@ -24,8 +26,9 @@ def create():
     if manager.settings.visyn_core.security.store.no_security_store.enable:
         _log.info("Adding NoSecurityStore")
         return NoSecurityStore(
-            manager.settings.visyn_core.security.store.no_security_store.user,
-            manager.settings.visyn_core.security.store.no_security_store.roles,
+            user=manager.settings.visyn_core.security.store.no_security_store.user,
+            roles=manager.settings.visyn_core.security.store.no_security_store.roles,
+            properties=manager.settings.visyn_core.security.store.no_security_store.properties,
         )
 
     return None

--- a/visyn_core/security/store/oauth2_security_store.py
+++ b/visyn_core/security/store/oauth2_security_store.py
@@ -13,10 +13,11 @@ _log = logging.getLogger(__name__)
 class OAuth2SecurityStore(BaseStore):
     ui = "AutoLoginForm"
 
-    def __init__(self, cookie_name: str | None, signout_url: str | None, email_token_field: str | list[str]):
+    def __init__(self, cookie_name: str | None, signout_url: str | None, email_token_field: str | list[str], properties_fields: list[str]):
         self.cookie_name = cookie_name
         self.signout_url: str | None = signout_url
         self.email_token_fields = [email_token_field] if isinstance(email_token_field, str) else email_token_field
+        self.properties_fields = properties_fields
 
     def load_from_request(self, req: Request):
         token_field = manager.settings.visyn_core.security.store.oauth2_security_store.access_token_header_name
@@ -38,6 +39,7 @@ class OAuth2SecurityStore(BaseStore):
                     id=id,
                     roles=[],
                     oauth2_access_token=access_token,
+                    properties={key: user.get(key) for key in self.properties_fields},
                 )
         except Exception:
             _log.exception("Error in load_from_request")
@@ -65,9 +67,10 @@ def create():
     if manager.settings.visyn_core.security.store.oauth2_security_store.enable:
         _log.info("Adding OAuth2SecurityStore")
         return OAuth2SecurityStore(
-            manager.settings.visyn_core.security.store.oauth2_security_store.cookie_name,
-            manager.settings.visyn_core.security.store.oauth2_security_store.signout_url,
-            manager.settings.visyn_core.security.store.oauth2_security_store.email_token_field,
+            cookie_name=manager.settings.visyn_core.security.store.oauth2_security_store.cookie_name,
+            signout_url=manager.settings.visyn_core.security.store.oauth2_security_store.signout_url,
+            email_token_field=manager.settings.visyn_core.security.store.oauth2_security_store.email_token_field,
+            properties_fields=manager.settings.visyn_core.security.store.oauth2_security_store.properties_fields,
         )
 
     return None

--- a/visyn_core/settings/model.py
+++ b/visyn_core/settings/model.py
@@ -94,6 +94,7 @@ class NoSecurityStoreSettings(BaseModel):
     enable: bool = False
     user: str = "admin"
     roles: list[str] = []
+    properties: dict[str, Any] = {}
 
 
 class SecurityStoreSettings(BaseModel):

--- a/visyn_core/settings/model.py
+++ b/visyn_core/settings/model.py
@@ -48,6 +48,10 @@ class AlbSecurityStoreSettings(BaseModel):
     """
     Field in the JWT token that contains the email address of the user.
     """
+    properties_fields: list[str] = []
+    """
+    Fields in the JWT token payload that should be mapped to the properties of the user.
+    """
     audience: str | list[str] | None = None
     """
     Audience of the JWT token.
@@ -77,6 +81,13 @@ class OAuth2SecurityStoreSettings(BaseModel):
     signout_url: str | None = None
     access_token_header_name: str = "X-Forwarded-Access-Token"
     email_token_field: str | list[str] = ["email"]
+    """
+    Field in the JWT token that contains the email address of the user.
+    """
+    properties_fields: list[str] = []
+    """
+    Fields in the JWT token payload that should be mapped to the properties of the user.
+    """
 
 
 class NoSecurityStoreSettings(BaseModel):

--- a/visyn_core/tests/test_security_login.py
+++ b/visyn_core/tests/test_security_login.py
@@ -119,6 +119,7 @@ def test_alb_security_store(client: TestClient):
     # Add some basic configuration
     manager.settings.visyn_core.security.store.alb_security_store.enable = True
     manager.settings.visyn_core.security.store.alb_security_store.email_token_field = ["field1", "field2", "email"]
+    manager.settings.visyn_core.security.store.alb_security_store.properties_fields = ["sub", "exp"]
     manager.settings.visyn_core.security.store.alb_security_store.decode_options = {"verify_signature": False}
     manager.settings.visyn_core.security.store.alb_security_store.cookie_name = "TestCookie"
     manager.settings.visyn_core.security.store.alb_security_store.signout_url = "http://localhost/api/logout"
@@ -143,6 +144,7 @@ def test_alb_security_store(client: TestClient):
     assert response.status_code == 200
     assert response.json() != '"not_yet_logged_in"'
     assert response.json()["name"] == "admin@localhost"
+    assert response.json()["properties"] == {"sub": "admin", "exp": 1657188138.494586}
 
     # Logout and check if we get the correct redirect url
     response = client.post("/api/logout", headers=headers)
@@ -159,6 +161,8 @@ def test_oauth2_security_store(client: TestClient):
     manager.settings.visyn_core.security.store.oauth2_security_store.enable = True
     manager.settings.visyn_core.security.store.oauth2_security_store.cookie_name = "TestCookie"
     manager.settings.visyn_core.security.store.oauth2_security_store.signout_url = "http://localhost/api/logout"
+    manager.settings.visyn_core.security.store.oauth2_security_store.email_token_field = ["field1", "field2", "email"]
+    manager.settings.visyn_core.security.store.oauth2_security_store.properties_fields = ["sub"]
 
     store = create_oauth2_security_store()
     assert store is not None
@@ -178,6 +182,7 @@ def test_oauth2_security_store(client: TestClient):
     assert response.status_code == 200
     assert response.json() != '"not_yet_logged_in"'
     assert response.json()["name"] == "admin@localhost"
+    assert response.json()["properties"] == {"sub": "admin"}
 
     # Logout and check if we get the correct redirect url
     response = client.post("/api/logout", headers=headers)
@@ -200,6 +205,7 @@ def test_no_security_store(client: TestClient):
     assert user_info != '"not_yet_logged_in"'
     assert user_info["name"] == "test_name"
     assert user_info["roles"] == ["test_role"]
+    assert user_info["properties"] == {}
 
 
 def test_user_login_hooks(client: TestClient):

--- a/visyn_core/tests/test_security_login.py
+++ b/visyn_core/tests/test_security_login.py
@@ -195,6 +195,7 @@ def test_no_security_store(client: TestClient):
     manager.settings.visyn_core.security.store.no_security_store.enable = True
     manager.settings.visyn_core.security.store.no_security_store.user = "test_name"
     manager.settings.visyn_core.security.store.no_security_store.roles = ["test_role"]
+    manager.settings.visyn_core.security.store.no_security_store.properties = {"id": 123, "name": "test"}
 
     store = create_no_security_store()
     assert store is not None
@@ -205,7 +206,7 @@ def test_no_security_store(client: TestClient):
     assert user_info != '"not_yet_logged_in"'
     assert user_info["name"] == "test_name"
     assert user_info["roles"] == ["test_role"]
-    assert user_info["properties"] == {}
+    assert user_info["properties"] == {"id": 123, "name": "test"}
 
 
 def test_user_login_hooks(client: TestClient):


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [x] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Adds `properties_fields` to the ALB and OAuth2 security stores to enable picking properties from the JWT payload.
  - Use case: imagine if there is a field "important_property" in the JWT payload. Currently, there is no way to retrieve this property. Now, just add  "important_property" to your security store settings under `properties_fields` and you have it. 

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
