### PR TITLE
feat: increate Sentry proxy timeout and only return select headers

### DIFF
--- a/visyn_core/sentry/sentry_proxy_router.py
+++ b/visyn_core/sentry/sentry_proxy_router.py
@@ -32,6 +32,13 @@ async def proxy_sentry_envelope(request: Request):  # pyright: ignore[reportUnus
                 content=envelope,
                 headers={"Content-Type": "application/x-sentry-envelope"},
             )
-            return Response(status_code=res.status_code, content=res.content, headers=res.headers)
+            return Response(
+                status_code=res.status_code,
+                content=res.content,
+                headers={
+                    "Content-Type": res.headers.get("Content-Type"),
+                    "X-Sentry-Error": res.headers.get("X-Sentry-Error"),
+                },
+            )
     else:
         return Response(status_code=500, content="Sentry is not configured")

--- a/visyn_core/settings/model.py
+++ b/visyn_core/settings/model.py
@@ -202,7 +202,7 @@ class SentrySettings(BaseModel):
     """
     Verify the SSL certificate of the frontend proxy.
     """
-    frontend_proxy_timeout: int = 10
+    frontend_proxy_timeout: int = 30
     """
     Timeout in seconds for the frontend proxy.
     """


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- The default timeout of 10s is apparently too little for Sentry, so we bump it to 30s
- We also only return a few select headers to avoid NGINX issues

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
