### PR TITLE
feat: parse commands after init_app such that everything is loaded

### DIFF
--- a/src/base/clientConfig.ts
+++ b/src/base/clientConfig.ts
@@ -16,6 +16,7 @@ import { Ajax } from './ajax';
  */
 export interface IClientConfig {
   env?: 'development' | 'production';
+  e2e?: boolean;
   sentry_dsn?: string;
   sentry_proxy_to?: string;
 }

--- a/visyn_core/dbmigration/manager.py
+++ b/visyn_core/dbmigration/manager.py
@@ -226,7 +226,10 @@ class DBMigrationManager:
             )
 
             # Store migration
-            self._migrations[migration.id] = migration
+            self.add_migration(migration)
+
+    def add_migration(self, migration: DBMigration):
+        self._migrations[migration.id] = migration
 
     def __contains__(self, item):
         return item in self._migrations

--- a/visyn_core/server/visyn_server.py
+++ b/visyn_core/server/visyn_server.py
@@ -190,17 +190,6 @@ def create_visyn_server(*, fast_api_args: dict[str, Any] | None = None, start_cm
 
     app.state.id_mapping = manager.id_mapping = create_id_mapping_manager()
 
-    # TODO: Allow custom command routine (i.e. for db-migrations)
-    from .cmd import parse_command_string
-
-    alternative_start_command = parse_command_string(start_cmd)
-    if alternative_start_command:
-        _log.info(f"Received start command: {start_cmd}")
-        alternative_start_command()
-        _log.info("Successfully executed command, exiting server...")
-        # TODO: How to properly exit here? Should a command support the "continuation" of the server, i.e. by returning True?
-        sys.exit(0)
-
     # Load all namespace plugins as WSGIMiddleware plugins
     from fastapi.middleware.wsgi import WSGIMiddleware
 
@@ -245,6 +234,17 @@ def create_visyn_server(*, fast_api_args: dict[str, Any] | None = None, start_cm
     # As a last step, call init_app callback for every plugin. This is last to ensure everything we need is already initialized.
     for p in plugins:
         p.plugin.init_app(app)
+
+    # TODO: Allow custom command routine (i.e. for db-migrations)
+    from .cmd import parse_command_string
+
+    alternative_start_command = parse_command_string(start_cmd)
+    if alternative_start_command:
+        _log.info(f"Received start command: {start_cmd}")
+        alternative_start_command()
+        _log.info("Successfully executed command, exiting server...")
+        # TODO: How to properly exit here? Should a command support the "continuation" of the server, i.e. by returning True?
+        sys.exit(0)
 
     # Load `after_server_started` extension points which are run immediately after server started,
     # so all plugins should have been loaded at this point of time

--- a/visyn_core/server/visyn_server.py
+++ b/visyn_core/server/visyn_server.py
@@ -166,8 +166,8 @@ def create_visyn_server(
                 f"Could not set the total number of anyio tokens to {manager.settings.visyn_core.total_anyio_tokens}. Error: {e}"
             )
 
-    if manager.settings.visyn_core.cypress:
-        _log.info("Cypress mode is enabled. This should only be used in a Cypress testing environment or CI.")
+    if manager.settings.is_e2e_testing:
+        _log.info("E2E mode is enabled. This should only be used in a E2E testing environment or CI.")
 
     # As a last step, call init_app callback for every plugin. This is last to ensure everything we need is already initialized.
     for p in plugins:

--- a/visyn_core/settings/client_config.py
+++ b/visyn_core/settings/client_config.py
@@ -41,6 +41,7 @@ def visyn_client_config(callback: Callable[[], type[BaseModel]] | type[BaseModel
 @visyn_client_config
 class VisynCoreClientConfigModel(BaseModel):
     env: Literal["development", "production"] = Field(default_factory=lambda: manager.settings.env)
+    e2e: bool = Field(default_factory=lambda: manager.settings.is_e2e_testing)
     sentry_dsn: str | None = Field(default_factory=lambda: manager.settings.visyn_core.sentry.get_frontend_dsn())
     sentry_proxy_to: str | None = Field(
         default_factory=lambda: "/api/sentry/" if manager.settings.visyn_core.sentry.get_frontend_proxy_to() else None

--- a/visyn_core/settings/model.py
+++ b/visyn_core/settings/model.py
@@ -235,23 +235,27 @@ class VisynCoreSettings(BaseModel):
     """
     sentry: SentrySettings = SentrySettings()
     """
-    Settings for celery. If not set, celery will not be initialized.
+    Settings for Sentry. DSN will be shared via the client config.
     """
     celery: dict[str, Any] | None = None
     """
-    Settings for Sentry. DSN will be shared via the client config.
+    Settings for celery. If not set, celery will not be initialized.
     """
     cypress: bool = False
     """
-    True if the application is running in Cypress testing environment. Enables application to return special responses for example.
+    @deprecated: Use `e2e` instead.
+    """
+    e2e: bool = False
+    """
+    True if the application is running in E2E testing environment. Enables application to return special responses for example.
 
-    To enable this flag in applications, simply add `VISYN_CORE__CYPRESS=true` to your `.env` file.
+    To enable this flag in applications, simply add `VISYN_CORE__E2E=true` to your `.env` file.
 
     Example usage in a route:
     ```
     from visyn_core import manager
     ...
-    if manager.settings.visyn_core.cypress:
+    if manager.settings.visyn_core.e2e:
         # Do something
     ```
     """
@@ -306,6 +310,10 @@ class GlobalSettings(BaseSettings):
     @property
     def is_development_mode(self) -> bool:
         return self.env.startswith("dev")
+
+    @property
+    def is_e2e_testing(self) -> bool:
+        return self.visyn_core.cypress or self.visyn_core.e2e
 
     def get_nested(self, key: str, default: Any = None) -> Any | None:
         """

--- a/visyn_core/tests/fixtures/app.py
+++ b/visyn_core/tests/fixtures/app.py
@@ -32,21 +32,19 @@ def workspace_config() -> dict:
 
 @pytest.fixture
 def app(workspace_config) -> FastAPI:
-    # Reset the client config globals
-    client_config._has_been_initialized = False
-    client_config._configs = []
+    # Only initialize the client config once
+    if not client_config._has_been_initialized:
+        # Example client config used in tests
+        @client_config.visyn_client_config
+        def _get_model():
+            class MyFunctionAppConfigModel(BaseModel):
+                demo_from_function: bool = False
 
-    # Example client config used in tests
-    @client_config.visyn_client_config
-    def _get_model():
-        class MyFunctionAppConfigModel(BaseModel):
-            demo_from_function: bool = False
+            return MyFunctionAppConfigModel
 
-        return MyFunctionAppConfigModel
-
-    @client_config.visyn_client_config
-    class MyClassAppConfigModel(BaseModel):
-        demo_from_class: bool = False
+        @client_config.visyn_client_config
+        class MyClassAppConfigModel(BaseModel):
+            demo_from_class: bool = False
 
     return create_visyn_server(workspace_config=workspace_config)
 

--- a/visyn_core/tests/test_settings.py
+++ b/visyn_core/tests/test_settings.py
@@ -82,10 +82,24 @@ def test_server_start():
 
 def test_client_config(client: TestClient):
     # By default, we always return null for the clientConfig
-    assert client.get("/api/v1/visyn/clientConfig").json() == {"demo_from_function": False, "demo_from_class": False}
+    assert client.get("/api/v1/visyn/clientConfig").json() == {
+        "e2e": False,
+        "env": "production",
+        "sentry_dsn": None,
+        "sentry_proxy_to": None,
+        "demo_from_function": False,
+        "demo_from_class": False,
+    }
 
     # Update the clientConfig in the settings
     manager.settings.visyn_core.client_config = {"demo_from_function": True, "demo_from_class": True}
 
     # Assert we receive exactly the client_config as result
-    assert client.get("/api/v1/visyn/clientConfig").json() == {"demo_from_function": True, "demo_from_class": True}
+    assert client.get("/api/v1/visyn/clientConfig").json() == {
+        "e2e": False,
+        "env": "production",
+        "sentry_dsn": None,
+        "sentry_proxy_to": None,
+        "demo_from_function": True,
+        "demo_from_class": True,
+    }


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Many apps are now using the `init_app` instead of `register` to add their routes, which is currently executed after the custom commands. This means any migrations or so are not available, as they haven't been executed yet.
- Minor change: this is a dev-only feature for listing and executing migrations, so changing it to the new way won't break anything (but actually fix things!)

But how do I actually use custom commands? Simple: 

```
python -m <app>.dev_app db-migration exec <migration-id> upgrade head
```

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
