### PR TITLE
feat: add VisynEvents to send global events, incl. better Sentry integration

### DIFF
--- a/src/app/VisynAppContext.tsx
+++ b/src/app/VisynAppContext.tsx
@@ -7,10 +7,14 @@ export const VisynAppContext = React.createContext<{
   user: IUser | null;
   appName: JSX.Element | string;
   clientConfig: IClientConfig | null;
+  successfulClientConfigInit: boolean;
+  successfulSentryInit: boolean | 'skipped';
 }>({
   user: null,
   appName: '',
   clientConfig: null,
+  successfulClientConfigInit: false,
+  successfulSentryInit: false,
 });
 
 export function useVisynAppContext() {

--- a/src/app/VisynAppProvider.tsx
+++ b/src/app/VisynAppProvider.tsx
@@ -82,16 +82,7 @@ export function VisynAppProvider({
     setSuccessfulClientConfigInit(true);
   }
 
-  const context = React.useMemo(
-    () => ({
-      user,
-      appName,
-      clientConfig,
-    }),
-    [user, appName, clientConfig],
-  );
-
-  const [successfulSentryInit, setSuccessfulSentryInit] = React.useState<boolean>(false);
+  const [successfulSentryInit, setSuccessfulSentryInit] = React.useState<boolean | 'skipped'>(false);
   React.useEffect(() => {
     // Hook to initialize Sentry if a DSN is provided.
     if (clientConfig?.sentry_dsn) {
@@ -129,7 +120,7 @@ export function VisynAppProvider({
       });
     } else if (successfulClientConfigInit) {
       // If the client config is loaded but no DSN is provided, we can set the successful Sentry init.
-      setSuccessfulSentryInit(true);
+      setSuccessfulSentryInit('skipped');
     }
   }, [clientConfig, successfulClientConfigInit, sentryInitOptions]);
 
@@ -147,6 +138,17 @@ export function VisynAppProvider({
   }, [clientConfig?.sentry_dsn, sentryOptions?.setUser, user]);
 
   const mergedMantineProviderProps = React.useMemo(() => merge(merge({}, DEFAULT_MANTINE_PROVIDER_PROPS), mantineProviderProps || {}), [mantineProviderProps]);
+
+  const context = React.useMemo<Parameters<typeof VisynAppContext.Provider>[0]['value']>(
+    () => ({
+      user,
+      appName,
+      clientConfig,
+      successfulClientConfigInit,
+      successfulSentryInit,
+    }),
+    [user, appName, clientConfig, successfulClientConfigInit, successfulSentryInit],
+  );
 
   return (
     <VisProvider>

--- a/src/app/VisynAppProvider.tsx
+++ b/src/app/VisynAppProvider.tsx
@@ -11,6 +11,7 @@ import { useAsync, useInitVisynApp } from '../hooks';
 import { VisynAppContext } from './VisynAppContext';
 import { dispatchVisynEvent } from './VisynEvents';
 import { DEFAULT_MANTINE_PROVIDER_PROPS } from './constants';
+import { VisynEnv } from '../base/VisynEnv';
 import { useVisynEventCallback } from '../hooks/useVisynEventCallback';
 import { userSession } from '../security/UserSession';
 import type { IUser } from '../security/interfaces';
@@ -91,6 +92,7 @@ export function VisynAppProvider({
         if (!Sentry.isInitialized()) {
           const resolvedSentryInitOptions = typeof sentryInitOptions === 'function' ? await sentryInitOptions() : sentryInitOptions;
           const client = Sentry.init({
+            release: `${VisynEnv.__APP_NAME__}@${VisynEnv.__VERSION__}`,
             /*
             Do not instantiate integrations here, as the apps should do this instead.
             integrations: [

--- a/src/app/VisynAppProvider.tsx
+++ b/src/app/VisynAppProvider.tsx
@@ -52,6 +52,7 @@ export function VisynAppProvider({
   sentryOptions?: {
     /**
      * Set the user in Sentry. Defaults to true.
+     * @deprecated Uses the `sendDefaultPii` from now on.
      */
     setUser?: boolean;
   };
@@ -125,17 +126,17 @@ export function VisynAppProvider({
   }, [clientConfig, successfulClientConfigInit, sentryInitOptions]);
 
   React.useEffect(() => {
-    // Hook to set the user in Sentry if a DSN is provided and the user is set.
-    if (clientConfig?.sentry_dsn && user && sentryOptions?.setUser !== false) {
+    // Hook to set the user in Sentry if it is initialized and the user is set.
+    if (successfulSentryInit === true && user) {
       import('@sentry/react').then((Sentry) => {
-        if (Sentry.isInitialized()) {
+        if (Sentry.isInitialized() && Sentry.getClient()?.getOptions()?.sendDefaultPii) {
           Sentry.setUser({
             id: user.name,
           });
         }
       });
     }
-  }, [clientConfig?.sentry_dsn, sentryOptions?.setUser, user]);
+  }, [successfulSentryInit, user]);
 
   const mergedMantineProviderProps = React.useMemo(() => merge(merge({}, DEFAULT_MANTINE_PROVIDER_PROPS), mantineProviderProps || {}), [mantineProviderProps]);
 

--- a/src/app/VisynEvents.ts
+++ b/src/app/VisynEvents.ts
@@ -1,0 +1,39 @@
+import type { Client } from '@sentry/core';
+
+import type { ILogoutOptions, IUser } from '../security';
+
+/**
+ * Definition of the custom events that can be dispatched and listened to.
+ */
+export interface VisynEventMap {
+  sentryInitialized: { client: Client | undefined };
+  userLoggedIn: { user: IUser | null };
+  userLoggedOut: { options: ILogoutOptions };
+}
+
+/**
+ * Typed custom event.
+ */
+export type VisynEvent<K extends keyof VisynEventMap> = CustomEvent<VisynEventMap[K]>;
+
+/**
+ * Dispatch a typed custom event.
+ */
+export function dispatchVisynEvent<K extends keyof VisynEventMap>(eventName: K, detail: VisynEventMap[K]): void {
+  const event = new CustomEvent(eventName, { detail });
+  window.dispatchEvent(event);
+}
+
+/**
+ * Listen for a typed custom event.
+ */
+export function addVisynEventListener<K extends keyof VisynEventMap>(eventName: K, callback: (event: CustomEvent<VisynEventMap[K]>) => void): void {
+  window.addEventListener(eventName, callback as EventListener);
+}
+
+/**
+ * Remove an event listener.
+ */
+export function removeVisynEventListener<K extends keyof VisynEventMap>(eventName: K, callback: (event: CustomEvent<VisynEventMap[K]>) => void): void {
+  window.removeEventListener(eventName, callback as EventListener);
+}

--- a/src/app/header/AboutAppModal.tsx
+++ b/src/app/header/AboutAppModal.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Center, Divider, Group, MantineSize, Modal, Space, Text, Title } from '@mantine/core';
 
-import { WebpackEnv } from '../../base';
+import { VisynEnv } from '../../base/VisynEnv';
 import { useVisynAppContext } from '../VisynAppContext';
 
 /**
@@ -61,14 +61,14 @@ export function AboutAppModal({
       size={size}
     >
       <Group my="md">{content}</Group>
-      {WebpackEnv.__VERSION__ ? (
+      {VisynEnv.__VERSION__ ? (
         <>
-          <Group style={{ gap: '4px' }}>
+          <Group gap="xs" wrap="nowrap">
             <Text fw={700} c="dimmed">
               Version:
             </Text>
             <Text>
-              {WebpackEnv.__VERSION__} {WebpackEnv.__BUILD_ID__ ? ` (${WebpackEnv.__BUILD_ID__})` : ''}
+              {VisynEnv.__VERSION__} {VisynEnv.__BUILD_ID__ ? ` (${VisynEnv.__BUILD_ID__})` : ''}
             </Text>
           </Group>
           <Space h="md" />

--- a/src/app/header/VisynHeader.stories.tsx
+++ b/src/app/header/VisynHeader.stories.tsx
@@ -38,6 +38,8 @@ const meta: Meta<typeof VisynHeader> = {
         clientConfig: {
           env: 'development' as const,
         },
+        successfulClientConfigInit: true,
+        successfulSentryInit: true,
       }),
       [],
     );

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -4,3 +4,4 @@ export * from './login';
 export * from './VisynApp';
 export * from './VisynAppProvider';
 export * from './VisynAppContext';
+export * from './VisynEvents';

--- a/src/base/AppContext.ts
+++ b/src/base/AppContext.ts
@@ -1,4 +1,4 @@
-import { WebpackEnv } from './WebpackEnv';
+import { VisynEnv } from './VisynEnv';
 import { Ajax } from './ajax';
 
 type OfflineGenerator = ((data: any, url: string) => Promise<any>) | Promise<any> | any;
@@ -10,19 +10,19 @@ export class AppContext {
    */
   public offline = false;
 
-  public static context = WebpackEnv.__APP_CONTEXT__;
+  public static context = VisynEnv.__APP_CONTEXT__;
 
   /**
    * version of the core
    */
-  public static version = WebpackEnv.__VERSION__;
+  public static version = VisynEnv.__VERSION__;
 
   // eslint-disable @typescript-eslint/naming-convention disable
   /**
    * server prefix of api calls
    * @type {string}
    */
-  public server_url = `${WebpackEnv.__APP_CONTEXT__ || '/'}api`;
+  public server_url = `${VisynEnv.__APP_CONTEXT__ || '/'}api`;
 
   /**
    * server suffix for api calls

--- a/src/base/VisynEnv.ts
+++ b/src/base/VisynEnv.ts
@@ -1,5 +1,9 @@
-export class WebpackEnv {
+export class VisynEnv {
   public static NODE_ENV = process.env.NODE_ENV;
+
+  public static __APP_NAME__ = process.env.__APP_NAME__;
+
+  public static __APP_DISPLAY_NAME__ = process.env.__APP_DISPLAY_NAME__;
 
   public static __VERSION__ = process.env.__VERSION__;
 
@@ -10,9 +14,9 @@ export class WebpackEnv {
   public static __APP_CONTEXT__ = process.env.__APP_CONTEXT__;
 
   public static __DEBUG__ = process.env.__DEBUG__;
-
-  /**
-   * enables features that used in reprovisyn
-   */
-  public static ENABLE_EXPERIMENTAL_REPROVISYN_FEATURES = process.env.ENABLE_EXPERIMENTAL_REPROVISYN_FEATURES === 'true';
 }
+
+/**
+ * @deprecated Use `VisynEnv` instead.
+ */
+export class WebpackEnv extends VisynEnv {}

--- a/src/base/event.ts
+++ b/src/base/event.ts
@@ -5,6 +5,7 @@ export interface IEventHandler {
 
 /**
  * basic interface of an event
+ * @deprecated Use `VisynEvents` instead.
  */
 export interface IEvent {
   /**
@@ -29,6 +30,9 @@ export interface IEvent {
   stopImmediatePropagation(): void;
 }
 
+/**
+ * @deprecated Use `VisynEvents` instead.
+ */
 export interface IEventListener {
   (event: IEvent, ...args: any[]): void;
 }
@@ -122,6 +126,7 @@ function propagateEvent(event: IEvent, target: IEventHandler) {
 
 /**
  * EventHandler base class
+ * @deprecated Use `VisynEvents` instead.
  */
 export class EventHandler implements IEventHandler {
   public static readonly MULTI_EVENT_SEPARATOR = ',';
@@ -228,6 +233,9 @@ export class EventHandler implements IEventHandler {
   };
 }
 
+/**
+ * @deprecated Use `VisynEvents` instead.
+ */
 export class GlobalEventHandler extends EventHandler {
   /**
    * @deprecated Use `globalEventHandler` instead.
@@ -238,4 +246,7 @@ export class GlobalEventHandler extends EventHandler {
   }
 }
 
+/**
+ * @deprecated Use `VisynEvents` instead.
+ */
 export const globalEventHandler = new EventHandler();

--- a/src/base/index.ts
+++ b/src/base/index.ts
@@ -3,4 +3,4 @@ export * from './interfaces';
 export * from './clientConfig';
 export * from './event';
 export * from './ajax';
-export * from './WebpackEnv';
+export * from './VisynEnv';

--- a/src/demo/MainApp.tsx
+++ b/src/demo/MainApp.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { Loader, Select, SimpleGrid, Stack, Text } from '@mantine/core';
 
-import { VisynApp, VisynHeader, useVisynAppContext } from '../app';
+import { VisynApp, VisynHeader } from '../app';
 import type { DatavisynTaggle } from '../ranking';
 import { VisynRanking } from '../ranking/VisynRanking';
 import {
@@ -16,12 +16,13 @@ import {
   Vis,
 } from '../vis';
 import { MyCategoricalScore, MyLinkScore, MyNumberScore, MySMILESScore, MyStringScore } from './scoresUtils';
+import { useVisynUser } from '../hooks';
 
 const { breastCancerData } = await import('../vis/stories/breastCancerData');
 const { fetchBreastCancerData } = await import('../vis/stories/fetchBreastCancerData');
 
 export function MainApp() {
-  const { user } = useVisynAppContext();
+  const user = useVisynUser();
   const [visConfig, setVisConfig] = React.useState<BaseVisConfig>({
     type: ESupportedPlotlyVis.SCATTER,
     numColumnsSelected: [

--- a/src/demo/index.initialize.tsx
+++ b/src/demo/index.initialize.tsx
@@ -4,6 +4,12 @@ import * as Sentry from '@sentry/react';
 import { createRoot } from 'react-dom/client';
 
 import { VisynAppProvider } from '../app/VisynAppProvider';
+import { addVisynEventListener } from '../app/VisynEvents';
+
+addVisynEventListener('sentryInitialized', ({ detail }) => {
+  // Demo of the visyn event listeners
+  console.log('Sentry initialized', detail.client);
+});
 
 const MainApp = React.lazy(() => import('./MainApp').then((module) => ({ default: module.MainApp })));
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -7,3 +7,5 @@ export * from './useSetRef';
 export * from './useDeepComparison';
 export * from './useDeepEffect';
 export * from './useDeepMemo';
+export * from './useVisynEventCallback';
+export * from './useVisynEventValue';

--- a/src/hooks/useVisynEventCallback.tsx
+++ b/src/hooks/useVisynEventCallback.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+
+import { useSyncedRef } from './useSyncedRef';
+import { VisynEventMap, addVisynEventListener, removeVisynEventListener } from '../app/VisynEvents';
+
+/**
+ * React hook to listen to event changes utilizing useSyncExternalStore.
+ */
+export function useVisynEventCallback<K extends keyof VisynEventMap>(eventName: K, callback: (event: CustomEvent<VisynEventMap[K]>) => void): void {
+  // Create a stable reference to the callback
+  const callbackRef = useSyncedRef(callback);
+  const stableCallback = React.useCallback(
+    (event: CustomEvent<VisynEventMap[K]>) => {
+      callbackRef.current(event);
+    },
+    [callbackRef],
+  );
+
+  // Add and remove the event listener
+  React.useEffect(() => {
+    addVisynEventListener(eventName, stableCallback);
+    return () => {
+      removeVisynEventListener(eventName, stableCallback);
+    };
+  }, [eventName, stableCallback]);
+}

--- a/src/hooks/useVisynEventValue.tsx
+++ b/src/hooks/useVisynEventValue.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+import { useVisynEventCallback } from './useVisynEventCallback';
+import { VisynEventMap } from '../app/VisynEvents';
+
+/**
+ * React hook to listen to the value of a specific event.
+ * @param eventName Name of the event to listen to.
+ * @returns The latest value of the event.
+ */
+export function useVisynEventValue<K extends keyof VisynEventMap>(
+  eventName: K,
+  defaultValue: VisynEventMap[K] | undefined = undefined,
+): VisynEventMap[K] | undefined {
+  const [value, setValue] = React.useState<VisynEventMap[K] | undefined>(defaultValue);
+  useVisynEventCallback<K>(eventName, (event) => setValue(event.detail));
+  return value;
+}

--- a/src/hooks/useVisynUser.ts
+++ b/src/hooks/useVisynUser.ts
@@ -1,29 +1,7 @@
-import React from 'react';
-
-import { globalEventHandler } from '../base/event';
-import { IUser, userSession } from '../security';
-import { UserSession } from '../security/UserSession';
+import { useVisynAppContext } from '../app/VisynAppContext';
+import { IUser } from '../security';
 
 export function useVisynUser(): IUser | null {
-  const [user, setUser] = React.useState<IUser | null>(userSession.currentUser());
-
-  React.useEffect(() => {
-    const loginListener = (_: any, u: IUser | null) => {
-      setUser(u);
-    };
-
-    const logoutListener = () => {
-      setUser(null);
-    };
-
-    globalEventHandler.on(UserSession.GLOBAL_EVENT_USER_LOGGED_IN, loginListener);
-    globalEventHandler.on(UserSession.GLOBAL_EVENT_USER_LOGGED_OUT, logoutListener);
-
-    return () => {
-      globalEventHandler.off(UserSession.GLOBAL_EVENT_USER_LOGGED_IN, loginListener);
-      globalEventHandler.off(UserSession.GLOBAL_EVENT_USER_LOGGED_OUT, logoutListener);
-    };
-  }, []);
-
+  const { user } = useVisynAppContext();
   return user;
 }

--- a/src/security/UserSession.ts
+++ b/src/security/UserSession.ts
@@ -28,42 +28,15 @@ export class UserSession {
   public static GLOBAL_EVENT_USER_LOGGED_OUT = 'USER_LOGGED_OUT';
 
   /**
-   * Use the browser's sessionStorage
-   * @type {Storage}
+   * Simply store the current user as variable instead of any browser storage
    */
-  private context: Storage = window.sessionStorage;
-
-  /**
-   * Store any value for a given key and returns the previous stored value.
-   * Returns `null` if no previous value was found.
-   * @param key
-   * @param value
-   * @returns {any}
-   */
-  public store = (key: string, value: any) => {
-    const bak = this.context.getItem(key);
-    this.context.setItem(key, JSON.stringify(value));
-    return bak;
-  };
-
-  /**
-   * Returns the value for the given key if it exists in the session.
-   * Otherwise returns the `default_` parameter, which is by default `null`.
-   * @param key
-   * @param defaultValue
-   * @returns {T}
-   */
-  public retrieve = <T>(key: string, defaultValue: T | null = null): T => {
-    return typeof this.context.getItem(key) === 'string' ? JSON.parse(this.context.getItem(key)!) : defaultValue;
-  };
+  private loggedInUser: IUser | null = null;
 
   /**
    * resets the stored session data that will be automatically filled during login
    */
   public reset = () => {
-    this.context.removeItem('logged_in');
-    this.context.removeItem('username');
-    this.context.removeItem('user');
+    this.loggedInUser = null;
   };
 
   /**
@@ -71,7 +44,7 @@ export class UserSession {
    * @returns {boolean}
    */
   public isLoggedIn = () => {
-    return this.retrieve('logged_in') === true;
+    return this.loggedInUser !== null;
   };
 
   /**
@@ -79,9 +52,7 @@ export class UserSession {
    * @param user
    */
   public login = (user: IUser) => {
-    this.store('logged_in', true);
-    this.store('username', user.name);
-    this.store('user', user);
+    this.loggedInUser = user;
 
     pluginRegistry.listPlugins(EP_PHOVEA_CORE_LOGIN).forEach((desc: ILoginExtensionPointDesc) => {
       desc.load().then((plugin: ILoginExtensionPoint) => plugin.factory(user));
@@ -118,13 +89,10 @@ export class UserSession {
 
   /**
    * returns the current user or null
-   * @returns {any}
+   * @returns {IUser | null}
    */
   public currentUser = (): IUser | null => {
-    if (!this.isLoggedIn()) {
-      return null;
-    }
-    return this.retrieve('user', UserUtils.ANONYMOUS_USER);
+    return this.loggedInUser;
   };
 
   /**

--- a/src/security/UserSession.ts
+++ b/src/security/UserSession.ts
@@ -1,6 +1,7 @@
 import { Permission } from './Permission';
 import { EEntity, EPermission, UserUtils } from './constants';
 import type { ISecureItem, IUser } from './interfaces';
+import { dispatchVisynEvent } from '../app/VisynEvents';
 import { globalEventHandler } from '../base/event';
 import { pluginRegistry } from '../plugin/PluginRegistry';
 import { EP_PHOVEA_CORE_LOGIN, EP_PHOVEA_CORE_LOGOUT, ILoginExtensionPoint, ILoginExtensionPointDesc, ILogoutEP, ILogoutEPDesc } from '../plugin/extensions';
@@ -20,8 +21,10 @@ export interface ILogoutOptions {
 }
 
 export class UserSession {
+  // TODO: Remove legacy event handling
   public static GLOBAL_EVENT_USER_LOGGED_IN = 'USER_LOGGED_IN';
 
+  // TODO: Remove legacy event handling
   public static GLOBAL_EVENT_USER_LOGGED_OUT = 'USER_LOGGED_OUT';
 
   /**
@@ -84,6 +87,8 @@ export class UserSession {
       desc.load().then((plugin: ILoginExtensionPoint) => plugin.factory(user));
     });
 
+    dispatchVisynEvent('userLoggedIn', { user });
+    // TODO: Remove legacy event handling
     globalEventHandler.fire(UserSession.GLOBAL_EVENT_USER_LOGGED_IN, user);
   };
 
@@ -99,6 +104,8 @@ export class UserSession {
       });
 
       // Notify all listeners
+      dispatchVisynEvent('userLoggedOut', { options });
+      // TODO: Remove legacy event handling
       globalEventHandler.fire(UserSession.GLOBAL_EVENT_USER_LOGGED_OUT, options);
 
       // Handle different logout options

--- a/src/security/watcher.ts
+++ b/src/security/watcher.ts
@@ -1,5 +1,6 @@
 import { LoginUtils } from './LoginUtils';
-import { UserSession, userSession } from './UserSession';
+import { userSession } from './UserSession';
+import { addVisynEventListener } from '../app/VisynEvents';
 import { Ajax } from '../base/ajax';
 import { globalEventHandler } from '../base/event';
 
@@ -13,11 +14,12 @@ export class SessionWatcher {
   private lastChecked = 0;
 
   constructor(private readonly logout: () => any = LoginUtils.logout) {
-    globalEventHandler.on(UserSession.GLOBAL_EVENT_USER_LOGGED_IN, () => this.reset());
+    addVisynEventListener('userLoggedIn', () => this.reset());
     if (userSession.isLoggedIn()) {
       this.reset();
     }
-    globalEventHandler.on(UserSession.GLOBAL_EVENT_USER_LOGGED_OUT, () => this.stop());
+    addVisynEventListener('userLoggedOut', () => this.stop());
+    // TODO: Remove legacy event handling
     globalEventHandler.on(Ajax.GLOBAL_EVENT_AJAX_POST_SEND, () => this.reset());
     document.addEventListener('visibilitychange', () => {
       window.clearInterval(this.hiddenTimeout);

--- a/visyn_core/plugin/parser.py
+++ b/visyn_core/plugin/parser.py
@@ -110,7 +110,7 @@ def get_config_from_plugins(plugins: list[EntryPointPlugin]) -> tuple[list[dict[
     for plugin in plugins:
         plugin_settings_model = plugin.plugin.setting_class
         if plugin_settings_model:
-            _log.info(f"Plugin {plugin.id} has a settings model")
+            _log.debug(f"Plugin {plugin.id} has a settings model")
             # Load the class of the config and wrap it in a tuple like (<clazz>, ...),
             # such that pydantic can use it as type-hint in the create_model class.
             # Otherwise, it would except <clazz> to be the default value...


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Why? I was looking for a way to let apps react to the `Sentry.init` event (both in React but also globally). We previously had the `globalEventHandler` mechanism, but that is completely untyped and uses a custom event system (inspired by jQuery). The modern way to do this is via `window.dispatchEvent`, and the `VisynEvent` is just a typed wrapper around it. 
- Migrates the `useVisynUser`, `watcher`, ... to the new mechanism, while keeping the old `fire` in place to ensure backwards compatibility. Removes usage of session storage to store user, as that is not recommended and has been replaced in favor of a "memory" store, i.e. a variable
- Exposes hooks `useVisynEventCallback` and `useVisynEventValue` to listen to the changes/values of the events.
- Adds a `main_app` entrypoint to the server to finally give us a way of what the primary plugin is. With that, we can send proper Sentry release information.

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
