### PR TITLE
fix: add legend toggle on click for controlled subplots

### DIFF
--- a/src/vis/scatter/ScatterVis.tsx
+++ b/src/vis/scatter/ScatterVis.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 
 import { css } from '@emotion/css';
-import { Center, Group, ScrollArea, Stack, Switch, Tooltip } from '@mantine/core';
+import { Button, Center, Group, ScrollArea, Stack, Switch, Tooltip } from '@mantine/core';
 import { useElementSize, useWindowEvent } from '@mantine/hooks';
 import * as d3v7 from 'd3v7';
 import cloneDeep from 'lodash/cloneDeep';
@@ -39,8 +39,14 @@ function Legend({
 }) {
   return (
     <Stack gap={0}>
-      <LegendItem color="transparent" label="Show All" onClick={() => onClick([])} filtered={hiddenCategoriesSet?.size === 0} />
-      <LegendItem color="transparent" label="Hide All" onClick={() => onClick(categories)} filtered={(hiddenCategoriesSet?.size ?? 0) >= categories.length} />
+      <Button.Group pb="sm">
+        <Button variant="default" size="compact-xs" onClick={() => onClick([])}>
+          Show all
+        </Button>
+        <Button variant="default" size="compact-xs" onClick={() => onClick(categories)}>
+          Hide all
+        </Button>
+      </Button.Group>
       <ScrollArea
         data-testid="PlotLegend"
         style={{ height: '100%' }}

--- a/src/vis/scatter/ScatterVis.tsx
+++ b/src/vis/scatter/ScatterVis.tsx
@@ -35,26 +35,30 @@ function Legend({
   categories: string[];
   hiddenCategoriesSet?: Set<string>;
   colorMap: (v: number | string) => string;
-  onClick: (category: string) => void;
+  onClick: (categories: string[]) => void;
 }) {
   return (
-    <ScrollArea
-      data-testid="PlotLegend"
-      style={{ height: '100%' }}
-      scrollbars="y"
-      className={css`
-        .mantine-ScrollArea-viewport > div {
-          display: flex !important;
-          flex-direction: column !important;
-        }
-      `}
-    >
-      <Stack gap={0}>
-        {categories.map((c) => (
-          <LegendItem key={c} color={colorMap(c)} label={c} onClick={() => onClick(c)} filtered={hiddenCategoriesSet?.has(c) ?? false} />
-        ))}
-      </Stack>
-    </ScrollArea>
+    <Stack gap={0}>
+      <LegendItem color="transparent" label="Show All" onClick={() => onClick([])} filtered={hiddenCategoriesSet?.size === 0} />
+      <LegendItem color="transparent" label="Hide All" onClick={() => onClick(categories)} filtered={(hiddenCategoriesSet?.size ?? 0) >= categories.length} />
+      <ScrollArea
+        data-testid="PlotLegend"
+        style={{ height: '100%' }}
+        scrollbars="y"
+        className={css`
+          .mantine-ScrollArea-viewport > div {
+            display: flex !important;
+            flex-direction: column !important;
+          }
+        `}
+      >
+        <Stack gap={0}>
+          {categories.map((c) => (
+            <LegendItem key={c} color={colorMap(c)} label={c} onClick={() => onClick([c])} filtered={hiddenCategoriesSet?.has(c) ?? false} />
+          ))}
+        </Stack>
+      </ScrollArea>
+    </Stack>
   );
 }
 
@@ -544,13 +548,19 @@ export function ScatterVis({
             categories={legendData.color.categories}
             colorMap={legendData.color.mappingFunction}
             hiddenCategoriesSet={hiddenCategoriesSet}
-            onClick={(category: string) => {
+            onClick={(categories: string[]) => {
               setHiddenCategoriesSet((prevSet) => {
                 const newSet = new Set(prevSet);
-                if (newSet.has(category)) {
-                  newSet.delete(category);
+                if (categories.length === 0) {
+                  return new Set<string>();
+                }
+                if (categories.length === legendData.color.categories.length) {
+                  return new Set<string>(legendData.color.categories);
+                }
+                if (newSet.has(categories[0] as string)) {
+                  newSet.delete(categories[0] as string);
                 } else {
-                  newSet.add(category);
+                  newSet.add(categories[0] as string);
                 }
                 return newSet;
               });

--- a/src/vis/scatter/useData.tsx
+++ b/src/vis/scatter/useData.tsx
@@ -190,8 +190,8 @@ export function useData({
         return {
           ...BASE_DATA,
           type: 'scattergl',
-          x: group.data.x,
-          y: group.data.y,
+          x: group.filter.map((index) => group.data.x[index]),
+          y: group.filter.map((index) => group.data.y[index]),
           xaxis: group.xref,
           yaxis: group.yref,
           mode: config.showLabels === ELabelingOptions.NEVER || config.xAxisScale === 'log' || config.yAxisScale === 'log' ? 'markers' : 'text+markers',
@@ -216,8 +216,8 @@ export function useData({
             ${value.shapeColumn && value.shapeColumn.info.id !== value.colorColumn?.info.id ? `<br />${columnNameWithDescription(value.shapeColumn.info)}: ${getLabelOrUnknown(group.data.shape[index])}` : ''}`.trim(),
           ),
           marker: {
-            color: value.colorColumn && mappingFunction ? group.data.color.map((v) => mappingFunction(v!)) : VIS_NEUTRAL_COLOR,
-            symbol: value.shapeColumn ? group.data.shape.map((shape) => shapeScale(shape as string)) : 'circle',
+            color: value.colorColumn && mappingFunction ? group.filter.map((index) => mappingFunction(group.data.color[index])) : VIS_NEUTRAL_COLOR,
+            symbol: value.shapeColumn ? group.filter.map((index) => shapeScale(group.data.shape[index] as string)) : 'circle',
             opacity: fullOpacityOrAlpha,
             size: 8,
           },

--- a/src/vis/scatter/useData.tsx
+++ b/src/vis/scatter/useData.tsx
@@ -78,21 +78,23 @@ export function useData({
         return {
           ...BASE_DATA,
           type: 'scattergl',
-          x: pair.x,
-          y: pair.y,
+          x: subplots.filter.map((index) => pair.x[index]),
+          y: subplots.filter.map((index) => pair.y[index]),
           xaxis: pair.xref,
           yaxis: pair.yref,
-          textposition: subplots.text.map((_, i) => textPositionOptions[i % textPositionOptions.length]),
+          textposition: subplots.filter.map((i) => textPositionOptions[i % textPositionOptions.length]),
           ...(isEmpty(selectedSet) ? {} : { selectedpoints: selectedList.map((idx) => subplots.idToIndex.get(idx)) }),
           mode: config.showLabels === ELabelingOptions.NEVER || config.xAxisScale === 'log' || config.yAxisScale === 'log' ? 'markers' : 'text+markers',
           ...(config.showLabels === ELabelingOptions.NEVER
             ? {}
             : config.showLabels === ELabelingOptions.ALWAYS
               ? {
-                  text: subplots.text.map((t) => truncateText(value.idToLabelMapper(t), true, 10)),
+                  text: subplots.filter.map((t) => truncateText(value.idToLabelMapper(subplots.text[t]!), true, 10)),
                 }
               : {
-                  text: subplots.text.map((t, i) => (visibleLabelsSet.has(subplots.ids[i]!) ? truncateText(value.idToLabelMapper(t), true, 10) : '')),
+                  text: subplots.filter.map((i) =>
+                    visibleLabelsSet.has(subplots.ids[i]!) ? truncateText(value.idToLabelMapper(subplots.text[i]!), true, 10) : '',
+                  ),
                 }),
           hovertext: subplots.ids.map((p_id, index) =>
             `${value.idToLabelMapper(p_id)}
@@ -101,8 +103,11 @@ export function useData({
             ${value.shapeColumn && value.shapeColumn.info.id !== value.colorColumn?.info.id ? `<br />${columnNameWithDescription(value.shapeColumn.info)}: ${getLabelOrUnknown(value.shapeColumn.resolvedValues[index]?.val)}` : ''}`.trim(),
           ),
           marker: {
-            color: value.colorColumn && mappingFunction ? value.colorColumn.resolvedValues.map((v) => mappingFunction(v.val)) : VIS_NEUTRAL_COLOR,
-            symbol: value.shapeColumn ? value.shapeColumn.resolvedValues.map((v) => shapeScale(v.val as string)) : 'circle',
+            color:
+              value.colorColumn && mappingFunction
+                ? subplots.filter.map((index) => mappingFunction(value.colorColumn.resolvedValues[index]?.val as string))
+                : VIS_NEUTRAL_COLOR,
+            symbol: value.shapeColumn ? subplots.filter.map((index) => shapeScale(value.shapeColumn.resolvedValues[index]?.val as string)) : 'circle',
             opacity: fullOpacityOrAlpha,
             size: 8,
           },
@@ -134,26 +139,26 @@ export function useData({
                   text: scatter.filter.map((index) => truncateText(value.idToLabelMapper(scatter.plotlyData.text[index]!), true, 10)),
                 }
               : {
-                  text: scatter.filter.map((index, i) =>
+                  text: scatter.filter.map((index) =>
                     visibleLabelsSet.has(scatter.ids[index]!)
                       ? truncateText(value.idToLabelMapper(value.idToLabelMapper(scatter.plotlyData.text[index]!)), true, 10)
                       : '',
                   ),
                 }),
-          hovertext: scatter.filter.map((i) => {
+          hovertext: scatter.filter.map((index) => {
             const resolvedLabelString =
               value.resolvedLabelColumns?.length > 0
-                ? value.resolvedLabelColumns.map((l) => `<b>${columnNameWithDescription(l.info)}</b>: ${getLabelOrUnknown(l.resolvedValues[i]?.val)}<br />`)
+                ? value.resolvedLabelColumns.map((l) => `<b>${columnNameWithDescription(l.info)}</b>: ${getLabelOrUnknown(l.resolvedValues[index]?.val)}<br />`)
                 : '';
-            const idString = `<b>${value.idToLabelMapper(scatter.plotlyData.text[i]!)}</b><br />`;
-            const xString = `<b>${columnNameWithDescription(value.validColumns[0]!.info)}</b>: ${getLabelOrUnknown(value.validColumns[0]!.resolvedValues[i]?.val)}<br />`;
-            const yString = `<b>${columnNameWithDescription(value.validColumns[1]!.info)}</b>: ${getLabelOrUnknown(value.validColumns[1]!.resolvedValues[i]?.val)}<br />`;
+            const idString = `<b>${value.idToLabelMapper(scatter.plotlyData.text[index]!)}</b><br />`;
+            const xString = `<b>${columnNameWithDescription(value.validColumns[0]!.info)}</b>: ${getLabelOrUnknown(value.validColumns[0]!.resolvedValues[index]?.val)}<br />`;
+            const yString = `<b>${columnNameWithDescription(value.validColumns[1]!.info)}</b>: ${getLabelOrUnknown(value.validColumns[1]!.resolvedValues[index]?.val)}<br />`;
             const colorColumnString = value.colorColumn
-              ? `<b>${columnNameWithDescription(value.colorColumn.info)}</b>: ${getLabelOrUnknown(value.colorColumn.resolvedValues[i]?.val)}<br />`
+              ? `<b>${columnNameWithDescription(value.colorColumn.info)}</b>: ${getLabelOrUnknown(value.colorColumn.resolvedValues[index]?.val)}<br />`
               : '';
             const shapeColumnString =
               value.shapeColumn && value.shapeColumn.info.id !== value.colorColumn?.info.id
-                ? `<b>${columnNameWithDescription(value.shapeColumn.info)}</b>: ${getLabelOrUnknown(value.shapeColumn.resolvedValues[i]?.val)}<br />`
+                ? `<b>${columnNameWithDescription(value.shapeColumn.info)}</b>: ${getLabelOrUnknown(value.shapeColumn.resolvedValues[index]?.val)}<br />`
                 : '';
 
             return `${idString}${xString}${yString}${resolvedLabelString}${colorColumnString}${shapeColumnString}`;
@@ -167,7 +172,7 @@ export function useData({
               value.colorColumn && mappingFunction
                 ? scatter.filter.map((index) => mappingFunction(value.colorColumn.resolvedValues[index]!.val as string))
                 : VIS_NEUTRAL_COLOR,
-            symbol: value.shapeColumn ? value.shapeColumn.resolvedValues.map((v) => shapeScale(v.val as string)) : 'circle',
+            symbol: value.shapeColumn ? scatter.filter.map((index) => shapeScale(value.shapeColumn.resolvedValues[index]!.val as string)) : 'circle',
             opacity: fullOpacityOrAlpha,
           },
           ...baseData(config.alphaSliderVal, !!value.colorColumn),

--- a/src/vis/scatter/useDataPreparation.ts
+++ b/src/vis/scatter/useDataPreparation.ts
@@ -242,9 +242,13 @@ export function useDataPreparation({
     );
 
     const resultData = groupedData.map((grouped, index) => {
+      const filter =
+        value.colorColumn && hiddenCategoriesSet
+          ? indicesOf(grouped, (e) => !hiddenCategoriesSet.has((e.color ?? NAN_REPLACEMENT) as string) && isFinite(e.x) && isFinite(e.y))
+          : range(grouped.map((v) => v.x).length);
       const idToIndex = new Map<string, number>();
-      grouped.forEach((v, vi) => {
-        idToIndex.set(v.ids, vi);
+      filter.forEach((i) => {
+        idToIndex.set(grouped[i]?.ids as string, i);
       });
 
       const x = grouped.map((v) => v.x as number);
@@ -252,7 +256,7 @@ export function useDataPreparation({
 
       return {
         data: {
-          validIndices: x.map((_, i) => (isFinite(x[i]) && isFinite(y[i]) ? i : null)).filter((i) => i !== null) as number[],
+          validIndices: filter,
           x,
           y,
           text: grouped.map((v) => v.ids),
@@ -262,6 +266,7 @@ export function useDataPreparation({
           shape: grouped.map((v) => v.shape),
         },
         idToIndex,
+        filter,
         xref: `x${index > 0 ? index + 1 : ''}` as PlotlyTypes.XAxisName,
         yref: `y${index > 0 ? index + 1 : ''}` as PlotlyTypes.YAxisName,
       };
@@ -275,7 +280,7 @@ export function useDataPreparation({
       yDomain,
       ids: value.validColumns[0].resolvedValues.map((v) => v.id),
     };
-  }, [status, value]);
+  }, [hiddenCategoriesSet, status, value]);
 
   const scales = React.useMemo(() => {
     if (!value) {

--- a/src/vis/scatter/useDataPreparation.ts
+++ b/src/vis/scatter/useDataPreparation.ts
@@ -184,7 +184,7 @@ export function useDataPreparation({
 
         xyPairs.push({
           data: {
-            validIndices: matrixItemFilter,
+            validIndices: matrixItemFilter, // TODO: check if matrixItemFilter is the same as filter
             x,
             y,
           },


### PR DESCRIPTION
Closes N/A

### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [x] Requires UI/UX/Vis review
  - [x] Reviewer(s) are notified @thinkh 
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes
- Added legend click behavior for controlled subplots

### Screenshots

https://github.com/user-attachments/assets/4832e9ff-8fe0-4d02-a1ed-d3022d93e6cd



### Additional notes for the reviewer(s)
- Shall I add the legend click to faceted and scatter plot matrix as well?
- This implementation might not be as straight forward