### PR TITLE
fix: height of facets with no data in bar chart

### DIFF
--- a/src/vis/bar/SingleEChartsBarChart.tsx
+++ b/src/vis/bar/SingleEChartsBarChart.tsx
@@ -484,7 +484,7 @@ function EagerSingleEChartsBarChart({
     isSuccess &&
     (visState.series.length === 0 ? (
       config?.facets && selectedFacetValue ? (
-        <Stack mih={DEFAULT_BAR_CHART_HEIGHT} align="center" justify="center" data-test-id={`visyn-bar-chart-no-data-error-facet-${selectedFacetValue}`}>
+        <Stack align="center" justify="center" data-test-id={`visyn-bar-chart-no-data-error-facet-${selectedFacetValue}`}>
           <Text style={{ textAlign: 'center' }}>{selectedFacetValue}</Text>
           <WarningMessage dataTestId={`visyn-vis-bar-chart-no-data-facet-${selectedFacetValue}-warning`}>No data available for this facet.</WarningMessage>
         </Stack>


### PR DESCRIPTION
Closes https://github.com/datavisyn/ordino/issues/2440
### Developer Checklist (Definition of Done)

**Issue**

- [ ] All acceptance criteria from the issue are met
- [ ] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [ ] Branch is up-to-date with the branch to be merged with, i.e., develop
- [ ] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [ ] Descriptive title for this pull request is provided (will be used for release notes later)
- [ ] Reviewer and assignees are defined
- [ ] Add type label (e.g., *bug*, *feature*) to this pull request
- [ ] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [ ] The PR is connected to the corresponding issue (via `Closes #...`)
- [ ] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- for facets with no value, the computed height is about `50` wheras the default component rendered has height 300 which is not included into the total height of the variable list. This causes the `no data for facet` message to overlap into the next bar. 
- I removed the min value, another solution is to modify the computed height for empty facets to be min `300`, i do not see this solution causing any side effects though.

### Screenshots

![gr22](https://github.com/user-attachments/assets/fd940caf-d6cd-4135-a9af-54aa7ca7154e)

### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
