### PR TITLE
fix: remove AsyncioIntegration as it breaks the SentryUserMiddleware

### DIFF
--- a/src/app/login/UserStoreUIMap.tsx
+++ b/src/app/login/UserStoreUIMap.tsx
@@ -124,7 +124,6 @@ export function AutoLoginForm({ setError, store }: IUserStoreRenderProps) {
           e.stopPropagation();
           login();
         }}
-        size="sm"
       >
         here
       </Anchor>{' '}

--- a/visyn_core/celery/app.py
+++ b/visyn_core/celery/app.py
@@ -28,7 +28,7 @@ def init_celery_manager(*, plugins: list[EntryPointPlugin]):
     return manager.celery
 
 
-def create_celery_worker_app(*, main_app: str = "visyn_core", workspace_config: dict | None = None):
+def create_celery_worker_app(*, main_app: str | None = None, workspace_config: dict | None = None):
     """
     Create a new Celery app in standalone mode, i.e. without a FastAPI instance.
     """

--- a/visyn_core/dev_celery.py
+++ b/visyn_core/dev_celery.py
@@ -2,4 +2,4 @@ import pathlib
 
 from .celery.app import create_celery_worker_app
 
-celery_app = create_celery_worker_app(main_app="visyn_core", workspace_config={"_env_file": pathlib.Path(__file__).parent / ".env"})
+celery_app = create_celery_worker_app(workspace_config={"_env_file": pathlib.Path(__file__).parent / ".env"})

--- a/visyn_core/server/visyn_server.py
+++ b/visyn_core/server/visyn_server.py
@@ -12,7 +12,7 @@ logging.config.dictConfig(default_logging_dict)
 
 def create_visyn_server(
     *,
-    main_app: str = "visyn_core",
+    main_app: str | None = None,
     fast_api_args: dict[str, Any] | None = None,
     start_cmd: str | None = None,
     workspace_config: dict | None = None,
@@ -32,6 +32,7 @@ def create_visyn_server(
     from .utils import init_settings_manager
 
     plugins = init_settings_manager(workspace_config=workspace_config)
+    main_app = manager.settings.visyn_core.main_app or main_app or "visyn_core"
     main_plugin = next(p for p in plugins if p.id == main_app)
 
     _log = logging.getLogger(__name__)

--- a/visyn_core/settings/client_config.py
+++ b/visyn_core/settings/client_config.py
@@ -58,5 +58,5 @@ def init_client_config(app: FastAPI):
 
     # Create an endpoint that returns the client config
     @app.get("/api/v1/visyn/clientConfig", tags=["Configuration"])
-    def _get_client_config() -> client_config_model:  # type: ignore
+    async def _get_client_config() -> client_config_model:  # type: ignore
         return client_config_model(**(manager.settings.visyn_core.client_config or {}))

--- a/visyn_core/settings/model.py
+++ b/visyn_core/settings/model.py
@@ -225,6 +225,10 @@ class SentrySettings(BaseModel):
 
 
 class VisynCoreSettings(BaseModel):
+    main_app: str | None = None
+    """
+    The main application starting the server, i.e. "visyn_core". Used to infer the app name and version from the plugin for telemetry/Sentry/...
+    """
     total_anyio_tokens: int = 100
     """
     The total number of threads to use for anyio. FastAPI uses these threads to run sync routes concurrently.


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Hotfix for sending username in the Python Sentry instrumentation. For some reason, the asyncio integration breaks it when using the current/isolation scope. 

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
