### PR TITLE
feat: split providers for more flexibility in apps

### DIFF
--- a/src/components/BlurredOverlay.tsx
+++ b/src/components/BlurredOverlay.tsx
@@ -32,6 +32,11 @@ export function BlurredOverlay({
       overlayProps={{
         blur: 2,
       }}
+      styles={{
+        root: {
+          padding: 'inherit',
+        },
+      }}
       // Set the zIndex explicitly to 200 (default 400) as it otherwise covers tooltips, popovers, ... (even within portals)
       zIndex={200}
       visible={visible || loading}


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Split the `VisynAppProvider` into `VisynAppMantineProvider` and `VisynAppContextProvider` for more flexibility in apps. I.e. sometimes you need the client config to initialize Redux, but when Mantine needs Redux (via modals for example) there is no way to do it in the old architecture. Now it's easy, just render the `VIsynAppContextProvider`, within you create the Redux stuff, and then render the `VisynAppMantineProvider`. 
- Non-breaking change as it just composes things differently, and is also opt-in.

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
