### PR TITLE
feat: Enable Python logger for RDKit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "visyn_core",
   "description": "Core repository for datavisyn applications.",
-  "version": "17.2.0",
+  "version": "17.2.1-SNAPSHOT",
   "author": {
     "name": "datavisyn GmbH",
     "email": "contact@datavisyn.io",

--- a/visyn_core/rdkit/img_api.py
+++ b/visyn_core/rdkit/img_api.py
@@ -21,7 +21,6 @@ app = APIRouter(prefix="/api/rdkit", tags=["RDKit"])
 
 # Tell the RDKit's C++ backend to use the python logger:
 rdBase.LogToPythonLogger()
-
 # RDKit comes with its own log config that we do not want: https://github.com/rdkit/rdkit/blob/master/rdkit/__init__.py#L28-L33
 # Undo the config RDKit does by default and use the root logger instead
 rdkit_logger = logging.getLogger("rdkit")
@@ -29,7 +28,6 @@ rdkit_logger = logging.getLogger("rdkit")
 rdkit_logger.setLevel(logging.NOTSET)
 # Enable propagation so messages go through our log handlers (so they use the same format)
 rdkit_logger.propagate = True
-
 # Remove RDKit's default handler to avoid duplicate messages
 rdkit_logger.handlers = []
 # Test:

--- a/visyn_core/rdkit/img_api.py
+++ b/visyn_core/rdkit/img_api.py
@@ -7,7 +7,6 @@ from rdkit.Chem.Scaffolds import MurckoScaffold  # type: ignore
 from starlette.responses import Response
 from starlette.status import HTTP_204_NO_CONTENT
 
-from ..settings.constants import default_logging_dict
 from .models import (
     SmilesMolecule,
     SmilesSmartsMolecule,
@@ -25,9 +24,9 @@ rdBase.LogToPythonLogger()
 
 # RDKit comes with its own log config that we do not want: https://github.com/rdkit/rdkit/blob/master/rdkit/__init__.py#L28-L33
 # Undo the config RDKit does by default and use the root logger instead
-rdkit_logger = logging.getLogger('rdkit')
+rdkit_logger = logging.getLogger("rdkit")
 # Unset rdkit's log level to use our configured log level
-rdkit_logger.setLevel(logging.NOTSET) 
+rdkit_logger.setLevel(logging.NOTSET)
 # Enable propagation so messages go through our log handlers (so they use the same format)
 rdkit_logger.propagate = True
 

--- a/visyn_core/rdkit/img_api.py
+++ b/visyn_core/rdkit/img_api.py
@@ -36,7 +36,7 @@ rdkit_logger.handlers = []
 # rdkit's default level is warning, while our root logger defaults to info --> next message should now be visible
 # rdkit_logger.info("RDKit logger: INFO message (should now be visible via root handler)")
 # from rdkit import Chem
-# Chem.MolFromSmiles("invalid_smiles_string_for_rdkit") # This should trigger a C++ ERROR log
+# Chem.MolFromSmiles("invalid_smiles_string_for_rdkit") # This will cause an error log in rdkit
 
 
 @app.get("/", response_class=SvgResponse)

--- a/visyn_core/rdkit/img_api.py
+++ b/visyn_core/rdkit/img_api.py
@@ -6,7 +6,6 @@ from rdkit.Chem import Mol  # type: ignore
 from rdkit.Chem.Scaffolds import MurckoScaffold  # type: ignore
 from starlette.responses import Response
 from starlette.status import HTTP_204_NO_CONTENT
-from uvicorn.logging import DefaultFormatter
 
 from ..settings.constants import default_logging_dict
 from .models import (
@@ -21,21 +20,24 @@ from .util.molecule import aligned, maximum_common_substructure_query_mol
 app = APIRouter(prefix="/api/rdkit", tags=["RDKit"])
 
 
-# Send RDKit's C++ logs to python logger
-# see https://greglandrum.github.io/rdkit-blog/posts/2024-02-23-custom-transformations-and-logging.html#connecting-the-rdkit-logs-to-the-python-logger
-logger = logging.getLogger("rdkit")  # defined here: https://github.com/rdkit/rdkit/blob/Release_2023_09_6/rdkit/__init__.py#L14
-# set the log level for the default log handler (the one which sends output to the console/notebook):
-# default is WARNING, see https://github.com/rdkit/rdkit/blob/Release_2023_09_6/rdkit/__init__.py#L32
-logger.handlers[0].setLevel(logging.INFO)
-# Set formatter to match the uvicorn logger we use:
-logger.handlers[0].setFormatter(
-    DefaultFormatter(
-        default_logging_dict["formatters"]["default"]["format"], datefmt=default_logging_dict["formatters"]["default"]["datefmt"]
-    )
-)
-
 # Tell the RDKit's C++ backend to use the python logger:
 rdBase.LogToPythonLogger()
+
+# RDKit comes with its own log config that we do not want: https://github.com/rdkit/rdkit/blob/master/rdkit/__init__.py#L28-L33
+# Undo the config RDKit does by default and use the root logger instead
+rdkit_logger = logging.getLogger('rdkit')
+# Unset rdkit's log level to use our configured log level
+rdkit_logger.setLevel(logging.NOTSET) 
+# Enable propagation so messages go through our log handlers (so they use the same format)
+rdkit_logger.propagate = True
+
+# Remove RDKit's default handler to avoid duplicate messages
+rdkit_logger.handlers = []
+# Test:
+# rdkit's default level is warning, while our root logger defaults to info --> next message should now be visible
+# rdkit_logger.info("RDKit logger: INFO message (should now be visible via root handler)")
+# from rdkit import Chem
+# Chem.MolFromSmiles("invalid_smiles_string_for_rdkit") # This should trigger a C++ ERROR log
 
 
 @app.get("/", response_class=SvgResponse)


### PR DESCRIPTION
Related to https://github.com/datavisyn/aevidence_pfizer_sync/pull/311

### Developer Checklist (Definition of Done)

**Issue**

- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] ~Unit tests are written (frontend/backend if applicable)~
- [ ] ~Integration tests are written (if applicable)~

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [ ] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

Sends RDKit's C++ logs to python logger.  

**Reason 1**: RDKit may, for example, log warnings when processing molecules, e.g.,
> [18:09:14] Warning: conflicting stereochemistry - bond wedging contradiction - at atom 26 ignored

The warning is 1) not returned via the API, and 2) does not include what was processed; making it hard/impossible to tell to which data it corresponds.

**Reason 2:** Consistent logging with the rest of the app.


Implemented as discussed in the RDKit Blog: https://greglandrum.github.io/rdkit-blog/posts/2024-02-23-custom-transformations-and-logging.html#connecting-the-rdkit-logs-to-the-python-logger

### Screenshots

![image](https://github.com/user-attachments/assets/38aa8825-c1ac-4777-9b0c-66388414c9fc)


### Additional notes for the reviewer(s)

Not sure if this is the right place to configure RDKit's logger, but seemed like the first place we are laoding/using RDKit.
