### PR TITLE
fix: use @types/plotly.js for plotly.js-dist-min

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@sentry/react": "^9.3.0",
     "@types/d3-hexbin": "^0.2.5",
     "@types/d3v7": "npm:@types/d3@^7.4.3",
-    "@types/plotly.js-dist-min": "^2.3.4",
+    "@types/plotly.js-dist-min": "npm:@types/plotly.js@^2.3.4",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "@types/react-plotly.js": "^2.6.3",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,6 @@
     "@types/plotly.js-dist-min": "npm:@types/plotly.js@^2.3.4",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
-    "@types/react-plotly.js": "^2.6.3",
     "arquero": "5.4.0",
     "comlink": "^4.4.2",
     "d3-force-boundary": "^0.0.3",

--- a/src/plotly/index.tsx
+++ b/src/plotly/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-unused-prop-types */
 /* eslint-disable import/first */
 if (typeof window.URL.createObjectURL === 'undefined') {
   // @ts-ignore
@@ -7,9 +8,100 @@ if (typeof window.URL.createObjectURL === 'undefined') {
 }
 
 import * as React from 'react';
-import type { PlotParams } from 'react-plotly.js';
 
 import type { Plotly as PlotlyTypes } from './full';
+
+// Copied types from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-plotly.js/index.d.ts
+// as it depends on "@types/plotly.js": "*", causing the latest/incompatible version to be installed.
+export interface Figure {
+  data: Plotly.Data[];
+  layout: Partial<Plotly.Layout>;
+  frames: Plotly.Frame[] | null;
+}
+
+export interface PlotParams {
+  data: Plotly.Data[];
+  layout: Partial<Plotly.Layout>;
+  frames?: Plotly.Frame[] | undefined;
+  config?: Partial<Plotly.Config> | undefined;
+  /**
+   * When provided, causes the plot to update only when the revision is incremented.
+   */
+  revision?: number | undefined;
+  /**
+   * Callback executed after plot is initialized.
+   * @param figure Object with three keys corresponding to input props: data, layout and frames.
+   * @param graphDiv Reference to the DOM node into which the figure was rendered.
+   */
+  onInitialized?: ((figure: Readonly<Figure>, graphDiv: Readonly<HTMLElement>) => void) | undefined;
+  /**
+   * Callback executed when when a plot is updated due to new data or layout, or when user interacts with a plot.
+   * @param figure Object with three keys corresponding to input props: data, layout and frames.
+   * @param graphDiv Reference to the DOM node into which the figure was rendered.
+   */
+  onUpdate?: ((figure: Readonly<Figure>, graphDiv: Readonly<HTMLElement>) => void) | undefined;
+  /**
+   * Callback executed when component unmounts, before Plotly.purge strips the graphDiv of all private attributes.
+   * @param figure Object with three keys corresponding to input props: data, layout and frames.
+   * @param graphDiv Reference to the DOM node into which the figure was rendered.
+   */
+  onPurge?: ((figure: Readonly<Figure>, graphDiv: Readonly<HTMLElement>) => void) | undefined;
+  /**
+   * Callback executed when a plotly.js API method rejects
+   * @param err Error
+   */
+  onError?: ((err: Readonly<Error>) => void) | undefined;
+  /**
+   * id assigned to the <div> into which the plot is rendered.
+   */
+  divId?: string | undefined;
+  /**
+   * applied to the <div> into which the plot is rendered
+   */
+  className?: string | undefined;
+  /**
+   * used to style the <div> into which the plot is rendered
+   */
+  style?: React.CSSProperties | undefined;
+  /**
+   * Assign the graph div to window.gd for debugging
+   */
+  debug?: boolean | undefined;
+  /**
+   * When true, adds a call to Plotly.Plot.resize() as a window.resize event handler
+   */
+  useResizeHandler?: boolean | undefined;
+
+  onAfterExport?: (() => void) | undefined;
+  onAfterPlot?: (() => void) | undefined;
+  onAnimated?: (() => void) | undefined;
+  onAnimatingFrame?: ((event: Readonly<Plotly.FrameAnimationEvent>) => void) | undefined;
+  onAnimationInterrupted?: (() => void) | undefined;
+  onAutoSize?: (() => void) | undefined;
+  onBeforeExport?: (() => void) | undefined;
+  onBeforeHover?: ((event: Readonly<Plotly.PlotMouseEvent>) => boolean) | undefined;
+  onButtonClicked?: ((event: Readonly<Plotly.ButtonClickEvent>) => void) | undefined;
+  onClick?: ((event: Readonly<Plotly.PlotMouseEvent>) => void) | undefined;
+  onClickAnnotation?: ((event: Readonly<Plotly.ClickAnnotationEvent>) => void) | undefined;
+  onDeselect?: (() => void) | undefined;
+  onDoubleClick?: (() => void) | undefined;
+  onFramework?: (() => void) | undefined;
+  onHover?: ((event: Readonly<Plotly.PlotHoverEvent>) => void) | undefined;
+  onLegendClick?: ((event: Readonly<Plotly.LegendClickEvent>) => boolean) | undefined;
+  onLegendDoubleClick?: ((event: Readonly<Plotly.LegendClickEvent>) => boolean) | undefined;
+  onRelayout?: ((event: Readonly<Plotly.PlotRelayoutEvent>) => void) | undefined;
+  onRestyle?: ((event: Readonly<Plotly.PlotRestyleEvent>) => void) | undefined;
+  onRedraw?: (() => void) | undefined;
+  onSelected?: ((event: Readonly<Plotly.PlotSelectionEvent>) => void) | undefined;
+  onSelecting?: ((event: Readonly<Plotly.PlotSelectionEvent>) => void) | undefined;
+  onSliderChange?: ((event: Readonly<Plotly.SliderChangeEvent>) => void) | undefined;
+  onSliderEnd?: ((event: Readonly<Plotly.SliderEndEvent>) => void) | undefined;
+  onSliderStart?: ((event: Readonly<Plotly.SliderStartEvent>) => void) | undefined;
+  onTransitioning?: (() => void) | undefined;
+  onTransitionInterrupted?: (() => void) | undefined;
+  onUnhover?: ((event: Readonly<Plotly.PlotMouseEvent>) => void) | undefined;
+  onWebGlContextLost?: (() => void) | undefined;
+}
 
 // Lazily load plotly.js-dist-min to allow code-splitting to occur, otherwise plotly is loaded everytime visyn_core is imported.
 const LazyPlotlyComponent = React.lazy(() =>
@@ -19,7 +111,7 @@ const LazyPlotlyComponent = React.lazy(() =>
     import('react-plotly.js/factory'),
   ]).then(([plotly, createPlotlyComponent]) => ({
     // Use the minified version for our own `Plotly` object
-    default: createPlotlyComponent.default(plotly.default),
+    default: createPlotlyComponent.default(plotly.default) as React.ComponentType<PlotParams>,
   })),
 );
 


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Our plotly types are breaking because `@types/plotly.js-dist-min` is referencing `@types/plotly.js` without any constraint: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/plotly.js-dist-min/package.json#L9, causing the latest (thus v3) to be installed. 
- Also inlined the `@types/react-plotly.js` types as they have the same issue...

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
