### PR TITLE
feat: set Sentry profiles_sample_rate to 0

### DIFF
--- a/visyn_core/sentry/sentry_integration.py
+++ b/visyn_core/sentry/sentry_integration.py
@@ -96,7 +96,7 @@ def init_sentry_integration(*, app: FastAPI, settings: "SentrySettings", verbose
             # Set sample_rate to 1.0 to sample 100% of transactions.
             "sample_rate": 1.0,
             # Set profiles_sample_rate to 1.0 to profile 100% of sampled transactions.
-            "profiles_sample_rate": 1.0,
+            "profiles_sample_rate": 0.0,
             # Set send_default_pii to True to send PII like the user's IP address.
             "send_default_pii": True,
             # Add some default integrations, but only if they are not set in the settings


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [ ] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Set profiles_sample_rate to 0 by default as it is now "Pay as you Go"
- It can always be enabled via the `visyn_core.sentry.backend_init_options`.

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
