### PR TITLE
feat: expand OAuth2 Security Store with ability to try multiple token headers

### DIFF
--- a/visyn_core/security/store/oauth2_security_store.py
+++ b/visyn_core/security/store/oauth2_security_store.py
@@ -4,6 +4,7 @@ import jwt
 from fastapi import Request
 
 from ... import manager
+from ...settings.model import OAuth2SecurityStoreHeader
 from ..model import LogoutReturnValue, User
 from .base_store import BaseStore
 
@@ -13,47 +14,79 @@ _log = logging.getLogger(__name__)
 class OAuth2SecurityStore(BaseStore):
     ui = "AutoLoginForm"
 
-    def __init__(self, cookie_name: str | None, signout_url: str | None, email_token_field: str | list[str], properties_fields: list[str]):
-        self.cookie_name = cookie_name
+    def __init__(
+        self,
+        token_field: str | None,
+        cookie_name: str | list[str] | None,
+        signout_url: str | None,
+        email_token_field: str | list[str] | None,
+        properties_fields: list[str] | None,
+        token_headers: list[OAuth2SecurityStoreHeader],
+    ):
+        self.cookie_name = [cookie_name] if isinstance(cookie_name, str) else cookie_name
         self.signout_url: str | None = signout_url
-        self.email_token_fields = [email_token_field] if isinstance(email_token_field, str) else email_token_field
-        self.properties_fields = properties_fields
+        # Define the list of token headers to be tried
+        self.token_headers = []
+
+        # Add the token headers to the list of new token headers
+        self.token_headers.extend(token_headers)
+
+        # Legacy fields for backwards compatibility
+        if token_field:
+            # Add the token field to the list of token headers
+            self.token_headers.append(
+                OAuth2SecurityStoreHeader(
+                    name=token_field,
+                    email_fields=([email_token_field] if isinstance(email_token_field, str) else email_token_field) or [],
+                    properties_fields=properties_fields or [],
+                )
+            )
+
+    def _load_user_from_token_header(self, req: Request, token_header: OAuth2SecurityStoreHeader):
+        # Get token data from header
+        _log.debug(f"Token header: {token_header}")
+        access_token = req.headers.get(token_header.name)
+        _log.debug(f"Token value: {access_token}")
+        if access_token:
+            # Remove any leading "Bearer " if exists
+            if access_token.startswith("Bearer "):
+                access_token = access_token.replace("Bearer ", "", 1)
+
+            user = jwt.decode(access_token, options={"verify_signature": False})
+
+            _log.debug(f"Decoded token: {user}")
+
+            # Go through all the fields we want to check for the user id
+            id = next((user.get(field, None) for field in token_header.email_fields if user.get(field, None)), None)
+            if not id:
+                _log.error(f"No {token_header.email_fields} matched in token, possible values: {user}")
+                return None
+
+            _log.debug(f"User id: {id}")
+            # Create new user from given attributes
+            return User(
+                id=id,
+                roles=[],
+                oauth2_access_token=access_token,
+                properties={key: user.get(key) for key in token_header.properties_fields},
+            )
 
     def load_from_request(self, req: Request):
-        token_field = manager.settings.visyn_core.security.store.oauth2_security_store.access_token_header_name
-        try:
-            # Get token data from header
-            access_token = req.headers.get(token_field)
-            if access_token:
-                # Remove any leading "Bearer " if exists
-                if access_token.startswith("Bearer "):
-                    access_token = access_token.replace("Bearer ", "", 1)
-
-                _log.debug(f"Try to decode the oidc data jwt with access token: {access_token}")
-                user = jwt.decode(access_token, options={"verify_signature": False})
-
-                # Go through all the fields we want to check for the user id
-                id = next((user.get(field, None) for field in self.email_token_fields if user.get(field, None)), None)
-                if not id:
-                    _log.error(f"No {self.email_token_fields} matched in token, possible values: {user}")
-                    return None
-
-                # Create new user from given attributes
-                return User(
-                    id=id,
-                    roles=[],
-                    oauth2_access_token=access_token,
-                    properties={key: user.get(key) for key in self.properties_fields},
-                )
-        except Exception:
-            _log.exception("Error in load_from_request")
-            return None
+        for token_header in self.token_headers:
+            try:
+                user = self._load_user_from_token_header(req, token_header)
+                if user:
+                    return user
+            except Exception:
+                _log.exception("Error in load_from_request")
+                return None
 
     def logout(self, user):
         # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/listener-authenticate-users.html#authentication-logout
         cookies = []
         if self.cookie_name:
-            cookies.append({"key": self.cookie_name, "value": "", "expires": -1})
+            for name in self.cookie_name:
+                cookies.append({"key": name, "value": "", "expires": -1})
         payload = {}
         # Redirect-URL to be triggered after logout. Makes sure to properly logout of the IdP provider.
         # See https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc#send-a-sign-out-request for details.
@@ -71,10 +104,12 @@ def create():
     if manager.settings.visyn_core.security.store.oauth2_security_store.enable:
         _log.info("Adding OAuth2SecurityStore")
         return OAuth2SecurityStore(
+            token_field=manager.settings.visyn_core.security.store.oauth2_security_store.access_token_header_name,
             cookie_name=manager.settings.visyn_core.security.store.oauth2_security_store.cookie_name,
             signout_url=manager.settings.visyn_core.security.store.oauth2_security_store.signout_url,
             email_token_field=manager.settings.visyn_core.security.store.oauth2_security_store.email_token_field,
             properties_fields=manager.settings.visyn_core.security.store.oauth2_security_store.properties_fields,
+            token_headers=manager.settings.visyn_core.security.store.oauth2_security_store.token_headers,
         )
 
     return None

--- a/visyn_core/settings/model.py
+++ b/visyn_core/settings/model.py
@@ -75,18 +75,43 @@ class AlbSecurityStoreSettings(BaseModel):
     """
 
 
-class OAuth2SecurityStoreSettings(BaseModel):
-    enable: bool = False
-    cookie_name: str | None = None
-    signout_url: str | None = None
-    access_token_header_name: str = "X-Forwarded-Access-Token"
-    email_token_field: str | list[str] = ["email"]
+class OAuth2SecurityStoreHeader(BaseModel):
+    name: str
+    """
+    Name of the header to extract the JWT token from.
+    """
+    email_fields: list[str] = []
     """
     Field in the JWT token that contains the email address of the user.
     """
     properties_fields: list[str] = []
     """
     Fields in the JWT token payload that should be mapped to the properties of the user.
+    """
+
+
+class OAuth2SecurityStoreSettings(BaseModel):
+    enable: bool = False
+    cookie_name: str | list[str] | None = None
+    signout_url: str | None = None
+    token_headers: list[OAuth2SecurityStoreHeader] = []
+    """
+    Headers from which the JWT token is extracted. The headers are extracted from the request and passed to the `jwt.decode` function.
+    The headers are tried in the order they are defined, and the first one that is found is used.
+    """
+    access_token_header_name: str | None = "X-Forwarded-Access-Token"
+    """
+    @deprecated: Use `headers` instead. This will be made read-only in the future.
+    """
+    email_token_field: str | list[str] | None = ["email"]
+    """
+    Field in the JWT token that contains the email address of the user.
+    @deprecated: Use `headers` instead. This will be made read-only in the future.
+    """
+    properties_fields: list[str] | None = []
+    """
+    Fields in the JWT token payload that should be mapped to the properties of the user.
+    @deprecated: Use `headers` instead. This will be made read-only in the future.
     """
 
 

--- a/visyn_core/settings/model.py
+++ b/visyn_core/settings/model.py
@@ -101,17 +101,17 @@ class OAuth2SecurityStoreSettings(BaseModel):
     """
     access_token_header_name: str | None = "X-Forwarded-Access-Token"
     """
-    @deprecated: Use `headers` instead. This will be made read-only in the future.
+    @deprecated: Use `token_headers` instead. This will be made read-only in the future.
     """
     email_token_field: str | list[str] | None = ["email"]
     """
     Field in the JWT token that contains the email address of the user.
-    @deprecated: Use `headers` instead. This will be made read-only in the future.
+    @deprecated: Use `token_headers` instead. This will be made read-only in the future.
     """
     properties_fields: list[str] | None = []
     """
     Fields in the JWT token payload that should be mapped to the properties of the user.
-    @deprecated: Use `headers` instead. This will be made read-only in the future.
+    @deprecated: Use `token_headers` instead. This will be made read-only in the future.
     """
 
 


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Previously, the OAuth2 security store was limited to consume tokens from a single headers. This is limiting if multiple headers may contain the relevant token (i.e. the access or ID token)
- Now, we can actually pass multiple token headers, falling back to the existing ones for full backwards compatibility.  

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
