### PR TITLE
fix: enable support for iterating through multiple headers even if exceptions are thrown

### DIFF
--- a/visyn_core/security/store/oauth2_security_store.py
+++ b/visyn_core/security/store/oauth2_security_store.py
@@ -4,7 +4,7 @@ import jwt
 from fastapi import Request
 
 from ... import manager
-from ...settings.model import OAuth2SecurityStoreHeader
+from ...settings.model import OAuth2SecurityStoreHeader, OAuth2SecurityStoreSettings
 from ..model import LogoutReturnValue, User
 from .base_store import BaseStore
 
@@ -16,59 +16,90 @@ class OAuth2SecurityStore(BaseStore):
 
     def __init__(
         self,
-        token_field: str | None,
-        cookie_name: str | list[str] | None,
-        signout_url: str | None,
-        email_token_field: str | list[str] | None,
-        properties_fields: list[str] | None,
-        token_headers: list[OAuth2SecurityStoreHeader],
+        settings: OAuth2SecurityStoreSettings,
     ):
-        self.cookie_name = [cookie_name] if isinstance(cookie_name, str) else cookie_name
-        self.signout_url: str | None = signout_url
+        self.cookie_name = [settings.cookie_name] if isinstance(settings.cookie_name, str) else settings.cookie_name
+        self.signout_url: str | None = settings.signout_url
+        self.use_user_headers = settings.use_user_headers
+        self.user_email_header = settings.user_email_header
+        self.user_groups_header = settings.user_groups_header
+
         # Define the list of token headers to be tried
-        self.token_headers = []
+        self.token_headers: list[OAuth2SecurityStoreHeader] = []
 
         # Add the token headers to the list of new token headers
-        self.token_headers.extend(token_headers)
+        self.token_headers.extend(settings.token_headers)
 
         # Legacy fields for backwards compatibility
-        if token_field:
+        if settings.access_token_header_name:
             # Add the token field to the list of token headers
             self.token_headers.append(
                 OAuth2SecurityStoreHeader(
-                    name=token_field,
-                    email_fields=([email_token_field] if isinstance(email_token_field, str) else email_token_field) or [],
-                    properties_fields=properties_fields or [],
+                    name=settings.access_token_header_name,
+                    email_fields=(
+                        [settings.email_token_field] if isinstance(settings.email_token_field, str) else settings.email_token_field
+                    )
+                    or [],
+                    roles_fields=(
+                        [settings.roles_token_field] if isinstance(settings.roles_token_field, str) else settings.roles_token_field
+                    )
+                    or [],
+                    properties_fields=settings.properties_fields or [],
                 )
             )
 
     def _load_user_from_token_header(self, req: Request, token_header: OAuth2SecurityStoreHeader):
         # Get token data from header
-        _log.debug(f"Token header: {token_header}")
         access_token = req.headers.get(token_header.name)
-        _log.debug(f"Token value: {access_token}")
+        _log.debug(f"Access token header: {token_header.name} and value: {access_token}")
+
+        if self.use_user_headers:
+            user_email = req.headers.get(self.user_email_header)
+            user_groups = req.headers.get(self.user_groups_header)
+            _log.debug(f"User email header: {self.user_email_header} and value: {user_email}")
+            _log.debug(f"NOT USED: User groups header: {self.user_groups_header} and value: {user_groups}")
+
+            if user_email:
+                return User(
+                    id=user_email,
+                    roles=[],  # TODO: What's the possible formats of user groups?
+                    access_token=access_token,
+                )
+
         if access_token:
             # Remove any leading "Bearer " if exists
             if access_token.startswith("Bearer "):
                 access_token = access_token.replace("Bearer ", "", 1)
 
-            user = jwt.decode(access_token, options={"verify_signature": False})
-
-            _log.debug(f"Decoded token: {user}")
+            access_token_payload = jwt.decode(access_token, options={"verify_signature": False})
+            _log.debug(f"Access token payload: {access_token_payload}")
 
             # Go through all the fields we want to check for the user id
-            id = next((user.get(field, None) for field in token_header.email_fields if user.get(field, None)), None)
+            id = next(
+                (access_token_payload.get(field, None) for field in token_header.email_fields if access_token_payload.get(field, None)),
+                None,
+            )
             if not id:
-                _log.error(f"No {token_header.email_fields} matched in token, possible values: {user}")
+                _log.warning(f"No {token_header.email_fields} matched in token, possible values: {access_token_payload}")
                 return None
 
-            _log.debug(f"User id: {id}")
+            # Go through all the fields we want to check for the user id
+            roles = next(
+                (
+                    access_token_payload.get(field, None)
+                    for field in token_header.roles_fields
+                    if access_token_payload.get(field, None) and isinstance(access_token_payload.get(field, None), list)
+                ),
+                None,
+            )
+
+            _log.debug(f"User id: {id} and roles: {roles}")
             # Create new user from given attributes
             return User(
                 id=id,
-                roles=[],
+                roles=roles or [],
                 oauth2_access_token=access_token,
-                properties={key: user.get(key) for key in token_header.properties_fields},
+                properties={key: access_token_payload.get(key) for key in token_header.properties_fields},
             )
 
     def load_from_request(self, req: Request):
@@ -77,9 +108,9 @@ class OAuth2SecurityStore(BaseStore):
                 user = self._load_user_from_token_header(req, token_header)
                 if user:
                     return user
-            except Exception:
-                _log.exception("Error in load_from_request")
-                return None
+            except Exception as e:
+                _log.warning(f"Error loading user from token header {token_header.name}: {e}")
+        return None
 
     def logout(self, user):
         # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/listener-authenticate-users.html#authentication-logout
@@ -104,12 +135,7 @@ def create():
     if manager.settings.visyn_core.security.store.oauth2_security_store.enable:
         _log.info("Adding OAuth2SecurityStore")
         return OAuth2SecurityStore(
-            token_field=manager.settings.visyn_core.security.store.oauth2_security_store.access_token_header_name,
-            cookie_name=manager.settings.visyn_core.security.store.oauth2_security_store.cookie_name,
-            signout_url=manager.settings.visyn_core.security.store.oauth2_security_store.signout_url,
-            email_token_field=manager.settings.visyn_core.security.store.oauth2_security_store.email_token_field,
-            properties_fields=manager.settings.visyn_core.security.store.oauth2_security_store.properties_fields,
-            token_headers=manager.settings.visyn_core.security.store.oauth2_security_store.token_headers,
+            settings=manager.settings.visyn_core.security.store.oauth2_security_store,
         )
 
     return None

--- a/visyn_core/settings/model.py
+++ b/visyn_core/settings/model.py
@@ -84,6 +84,10 @@ class OAuth2SecurityStoreHeader(BaseModel):
     """
     Field in the JWT token that contains the email address of the user.
     """
+    roles_fields: list[str] = []
+    """
+    Field in the JWT token that contains the roles of the user.
+    """
     properties_fields: list[str] = []
     """
     Fields in the JWT token payload that should be mapped to the properties of the user.
@@ -94,6 +98,18 @@ class OAuth2SecurityStoreSettings(BaseModel):
     enable: bool = False
     cookie_name: str | list[str] | None = None
     signout_url: str | None = None
+    use_user_headers: bool = False
+    """
+    If true, the X-Forwarded-Email and X-Forwarded-Groups headers are used to extract the email and roles of the user instead of the JWT token.
+    """
+    user_email_header: str = "X-Forwarded-Email"
+    """
+    If `use_user_headers` is true, this header is used to extract the email of the user.
+    """
+    user_groups_header: str = "X-Forwarded-Groups"
+    """
+    If `use_user_headers` is true, this header is used to extract the roles of the user.
+    """
     token_headers: list[OAuth2SecurityStoreHeader] = []
     """
     Headers from which the JWT token is extracted. The headers are extracted from the request and passed to the `jwt.decode` function.
@@ -106,6 +122,11 @@ class OAuth2SecurityStoreSettings(BaseModel):
     email_token_field: str | list[str] | None = ["email"]
     """
     Field in the JWT token that contains the email address of the user.
+    @deprecated: Use `token_headers` instead. This will be made read-only in the future.
+    """
+    roles_token_field: str | list[str] | None = ["groups"]
+    """
+    Field in the JWT token that contains the roles of the user.
     @deprecated: Use `token_headers` instead. This will be made read-only in the future.
     """
     properties_fields: list[str] | None = []

--- a/visyn_core/tests/test_security_login.py
+++ b/visyn_core/tests/test_security_login.py
@@ -201,7 +201,9 @@ def test_oauth2_security_store(client: TestClient):
 
     # Header created with a random token containing "email"
     headers = {
-        "X-Forwarded-Access-Token": jwt.encode({"email": "admin@localhost", "sub": "admin"}, "secret", algorithm="HS256"),
+        "X-Forwarded-Access-Token": jwt.encode(
+            {"email": "admin@localhost", "sub": "admin", "groups": ["role1", "role2"]}, "secret", algorithm="HS256"
+        ),
     }
 
     stores = client.get("/api/security/stores", headers=headers).json()
@@ -212,6 +214,7 @@ def test_oauth2_security_store(client: TestClient):
     assert response.status_code == 200
     assert response.json() != '"not_yet_logged_in"'
     assert response.json()["name"] == "admin@localhost"
+    assert response.json()["roles"] == ["role1", "role2"]
     assert response.json()["properties"] == {"sub": "admin"}
 
     # Logout and check if we get the correct redirect url
@@ -241,6 +244,7 @@ def test_oauth2_security_store_multiple_headers(client: TestClient):
     response = client.get(
         "/api/loggedinas",
         headers={
+            "X-Forwarded-Access-Token": "Invalid header",
             "X-Forwarded-Access-Token-3": jwt.encode({"email": "admin-3@localhost", "sub": "admin-3"}, "secret", algorithm="HS256"),
         },
     )


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [ ] All acceptance criteria from the issue are met
- [ ] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [ ] Branch is up-to-date with the branch to be merged with, i.e., develop
- [ ] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [ ] Descriptive title for this pull request is provided (will be used for release notes later)
- [ ] Reviewer and assignees are defined
- [ ] Add type label (e.g., *bug*, *feature*) to this pull request
- [ ] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [ ] The PR is connected to the corresponding issue (via `Closes #...`)
- [ ] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Previously, loading a user was aborted if an exception was thrown. Now it iterates through all user tokens even if exceptions are thrown.
- Adds `use_user_headers` to completely avoid decoding access tokens and use `X-Forwarded-Email` instead.

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
